### PR TITLE
Dependency cleanup

### DIFF
--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -54,12 +54,12 @@
       <artifactId>javax.annotation-api</artifactId>
       <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>javax.enterprise</groupId>
       <artifactId>cdi-api</artifactId>
       <scope>provided</scope>
     </dependency>
-
 
     <dependency>
       <groupId>javax.json</groupId>
@@ -68,19 +68,15 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jboss.spec.javax.servlet</groupId>
-      <artifactId>jboss-servlet-api_3.1_spec</artifactId>
-      <scope>provided</scope>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.9.1</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
     <version.org.jboss.logging.jboss-logging>3.3.1.Final</version.org.jboss.logging.jboss-logging>
     <version.org.jboss.weld.weld>2.4.3.Final</version.org.jboss.weld.weld>
     <version.weld>2.4.7.Final</version.weld>
+    <!-- Used by smallrye-metrics-rest-tck to download WildFly Servlet distribution -->
     <version.wildfly>13.0.0.Final</version.wildfly>
   </properties>
 


### PR DESCRIPTION
* Remove org.jboss.spec.javax.servlet dependency in the implementation
  (the Servlet is provided in the smallrye-metrics-rest-tck module)
* put Junit and AssertJ dependency in test scope