### PR TITLE
Lower MetricsInterceptor log priority to debug

### DIFF
--- a/implementation/src/main/java/io/smallrye/metrics/interceptors/MetricsInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/metrics/interceptors/MetricsInterceptor.java
@@ -55,7 +55,7 @@ public class MetricsInterceptor {
     @AroundConstruct
     private Object metrics(InvocationContext context) throws Exception {
         Class<?> bean = context.getConstructor().getDeclaringClass();
-        log.infof("MetricsInterceptor, bean=%s\n", bean);
+        log.debugf("MetricsInterceptor, bean=%s\n", bean);
         // Registers the bean constructor metrics
         MetricsMetadata.registerMetrics(registry, resolver, bean, context.getConstructor());
 


### PR DESCRIPTION
The  logger gets called on ever invocation of a metric, which seems a bit excessive for INFO level, e.g.

```
INFO  : Fri Jul 20 12:33:52 BST 2018 [io.smallrye.metrics.MetricsRegistryImpl] Register metric [name: io.mikecroft.MyResource.hello, type: meter]
INFO  : Fri Jul 20 12:33:52 BST 2018 [io.smallrye.metrics.MetricsRegistryImpl] Register metric [name: io.mikecroft.MyResource.two, type: meter]
INFO  : Fri Jul 20 12:48:02 BST 2018 [io.smallrye.metrics.interceptors.MetricsInterceptor] MetricsInterceptor, bean=class io.mikecroft.MyResource

INFO  : Fri Jul 20 12:48:03 BST 2018 [io.smallrye.metrics.interceptors.MetricsInterceptor] MetricsInterceptor, bean=class io.mikecroft.MyResource

INFO  : Fri Jul 20 12:48:04 BST 2018 [io.smallrye.metrics.interceptors.MetricsInterceptor] MetricsInterceptor, bean=class io.mikecroft.MyResource

INFO  : Fri Jul 20 12:48:04 BST 2018 [io.smallrye.metrics.interceptors.MetricsInterceptor] MetricsInterceptor, bean=class io.mikecroft.MyResource
```