### PR TITLE
[#9] Fix time unit conversion

### DIFF
--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -45,6 +45,13 @@
     </dependency>
 
     <dependency>
+      <groupId>io.smallrye</groupId>
+      <artifactId>smallrye-config</artifactId>
+      <version>${version.smallrye.config}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.jboss.logging</groupId>
       <artifactId>jboss-logging</artifactId>
     </dependency>

--- a/implementation/src/main/java/io/smallrye/metrics/exporters/PrometheusUnit.java
+++ b/implementation/src/main/java/io/smallrye/metrics/exporters/PrometheusUnit.java
@@ -17,6 +17,13 @@
 
 package io.smallrye.metrics.exporters;
 
+import static io.smallrye.metrics.exporters.ExporterUtil.NANOS_PER_DAY;
+import static io.smallrye.metrics.exporters.ExporterUtil.NANOS_PER_HOUR;
+import static io.smallrye.metrics.exporters.ExporterUtil.NANOS_PER_MICROSECOND;
+import static io.smallrye.metrics.exporters.ExporterUtil.NANOS_PER_MILLI;
+import static io.smallrye.metrics.exporters.ExporterUtil.NANOS_PER_MINUTE;
+import static io.smallrye.metrics.exporters.ExporterUtil.NANOS_PER_SECOND;
+
 import org.eclipse.microprofile.metrics.MetricUnits;
 
 /**
@@ -122,13 +129,25 @@ public class PrometheusUnit {
                 out = value * 1_000_000_000;
                 break;
             case MetricUnits.NANOSECONDS:
-            case MetricUnits.MICROSECONDS:
-            case MetricUnits.MILLISECONDS:
-            case MetricUnits.SECONDS:
-            case MetricUnits.MINUTES:
-            case MetricUnits.HOURS:
-            case MetricUnits.DAYS:
                 out = ExporterUtil.convertNanosTo(value, MetricUnits.SECONDS);
+                break;
+            case MetricUnits.MICROSECONDS:
+                out = ExporterUtil.convertNanosTo(value * NANOS_PER_MICROSECOND, MetricUnits.SECONDS);
+                break;
+            case MetricUnits.MILLISECONDS:
+                out = ExporterUtil.convertNanosTo(value * NANOS_PER_MILLI, MetricUnits.SECONDS);
+                break;
+            case MetricUnits.SECONDS:
+                out = ExporterUtil.convertNanosTo(value * NANOS_PER_SECOND, MetricUnits.SECONDS);
+                break;
+            case MetricUnits.MINUTES:
+                out = ExporterUtil.convertNanosTo(value * NANOS_PER_MINUTE, MetricUnits.SECONDS);
+                break;
+            case MetricUnits.HOURS:
+                out = ExporterUtil.convertNanosTo(value * NANOS_PER_HOUR, MetricUnits.SECONDS);
+                break;
+            case MetricUnits.DAYS:
+                out = ExporterUtil.convertNanosTo(value * NANOS_PER_DAY, MetricUnits.SECONDS);
                 break;
             default:
                 out = value;

--- a/implementation/src/test/java/io/smallrye/metrics/exporters/PrometheusUnitScalingTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/exporters/PrometheusUnitScalingTest.java
@@ -25,17 +25,24 @@ import org.junit.Test;
 public class PrometheusUnitScalingTest {
 
     @Test
+    public void testScaleToSecondsForNanos() {
+        String foo = MetricUnits.NANOSECONDS;
+        double out = PrometheusUnit.scaleToBase(foo, 3.0);
+        assert out == 0.000_000_003 : "Out was " + out;
+    }
+
+    @Test
     public void testScaleToSeconds() {
         String foo = MetricUnits.SECONDS;
         double out = PrometheusUnit.scaleToBase(foo, 3.0);
-        assert out == 0.000_000_003 : "Out was " + out;
+        assert out == 3 : "Out was " + out;
     }
 
     @Test
     public void testScaleToSecondsForDays() {
         String foo = MetricUnits.DAYS;
         double out = PrometheusUnit.scaleToBase(foo, 3.0);
-        assert out == 0.000_000_003 : "Out was " + out;
+        assert out == 3 * 24 * 60 * 60 : "Out was " + out;
     }
 
     @Test


### PR DESCRIPTION
* Fix time unit conversion in PrometheusUnit#scaleToBase where the time
  unit of the value was not taken into account before scaling it to
  seconds.
  The value is now converted to nanoseconds before calling
   ExporterUtil#convertNanosTo.
* Add PrometheusExporterTest#testUptimeGaugeUnitConversion that is
  hightlighting the issue when monitoring the jvm.uptime gauge
* Fix bogus tests in PrometheusUnitScalingTest that were not asserting
* that the scaled values are in seconds.

Issue: https://github.com/smallrye/smallrye-metrics/issues/9