### PR TITLE
[#12] MetricRegistry cleanup

### DIFF
--- a/implementation/src/main/java/io/smallrye/metrics/MetricRegistries.java
+++ b/implementation/src/main/java/io/smallrye/metrics/MetricRegistries.java
@@ -41,15 +41,15 @@ public class MetricRegistries {
     }
 
     @Produces
-    @ApplicationScoped
     @RegistryType(type = MetricRegistry.Type.BASE)
+    @ApplicationScoped
     public MetricRegistry getBaseRegistry() {
         return get(MetricRegistry.Type.BASE);
     }
 
     @Produces
-    @ApplicationScoped
     @RegistryType(type = MetricRegistry.Type.VENDOR)
+    @ApplicationScoped
     public MetricRegistry getVendorRegistry() {
         return get(MetricRegistry.Type.VENDOR);
     }
@@ -60,7 +60,7 @@ public class MetricRegistries {
 
     @PreDestroy
     public void cleanUp() {
-        registries.clear();
+        registries.remove(MetricRegistry.Type.APPLICATION);
     }
 
     private static final Map<MetricRegistry.Type, MetricRegistry> registries = new ConcurrentHashMap<>();


### PR DESCRIPTION
As the MetricRegistries is @ApplicationScoped, when it is destroyed, it
must clean up only the APPLICATION MetricRegistry.

Do not flag the `getBaseRegistry` and `getVendorRegistry` as
@ApplicationScope as they can be used outside of the application scope
(e.g. it's the responsibility of the container runtime to clean up its
vendor metrics).

JIRA: https://github.com/smallrye/smallrye-metrics/issues/12