### PR TITLE
Fix Counter implementation

### DIFF
--- a/implementation/src/main/java/io/smallrye/metrics/MetricsRegistryImpl.java
+++ b/implementation/src/main/java/io/smallrye/metrics/MetricsRegistryImpl.java
@@ -30,6 +30,7 @@ import org.eclipse.microprofile.metrics.Metric;
 import org.eclipse.microprofile.metrics.MetricFilter;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.MetricType;
+import org.eclipse.microprofile.metrics.MetricUnits;
 import org.eclipse.microprofile.metrics.Timer;
 import org.jboss.logging.Logger;
 
@@ -107,6 +108,14 @@ public class MetricsRegistryImpl extends MetricRegistry {
         //Gauges are not reusable
         if (metadata.getTypeRaw().equals(MetricType.GAUGE)) {
             reusableFlag = false;
+        }
+
+        if (metadata.getTypeRaw().equals(MetricType.COUNTER)) {
+            String unit = metadata.getUnit();
+            if (unit != null && !unit.isEmpty() && !unit.equals(MetricUnits.NONE)) {
+                // 3.2.3. Handling of units - Counter metrics are considered dimensionless
+                throw new IllegalArgumentException("Counter metric " + metadata.getName() + " must not provide unit");
+            }
         }
 
         if (metricMap.keySet().contains(metadata.getName()) && !reusableFlag) {

--- a/implementation/src/test/java/io/smallrye/metrics/exporters/MetricRegistryTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/exporters/MetricRegistryTest.java
@@ -1,0 +1,23 @@
+package io.smallrye.metrics.exporters;
+
+import io.smallrye.metrics.MetricRegistries;
+import io.smallrye.metrics.app.CounterImpl;
+import org.eclipse.microprofile.metrics.Metadata;
+import org.eclipse.microprofile.metrics.Metric;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricType;
+import org.eclipse.microprofile.metrics.MetricUnits;
+import org.junit.Test;
+
+public class MetricRegistryTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void counterMustNotProvideUnit() {
+        MetricRegistry registry = MetricRegistries.get(MetricRegistry.Type.APPLICATION);
+
+        Metric counter = new CounterImpl();
+        Metadata metadata = new Metadata("requestCount", MetricType.COUNTER);
+        metadata.setUnit(MetricUnits.DAYS);
+        registry.register(metadata, counter);
+    }
+}

--- a/testsuite/common/src/main/resources/io/smallrye/metrics/base-metrics.properties
+++ b/testsuite/common/src/main/resources/io/smallrye/metrics/base-metrics.properties
@@ -30,7 +30,7 @@ gc.%s.count.multi: true
 gc.%s.count.description:  Displays the total number of collections that have occurred. This attribute lists -1 if the collection count is undefined for this collector.
 gc.%s.count.mbean: java.lang:type=GarbageCollector,name=%s/CollectionCount
 gc.%s.time.displayName: Garbage Collection Time
-gc.%s.time.type: counter
+gc.%s.time.type: gauge
 gc.%s.time.unit: milliseconds
 gc.%s.time.multi: true
 gc.%s.time.description: Displays the approximate accumulated collection elapsed time in milliseconds. This attribute displays -1 if the collection elapsed time is undefined for this collector. The Java virtual machine implementation may use a high resolution timer to measure the elapsed time. This attribute may display the same value even if the collection count has been incremented if the collection elapsed time is very short.


### PR DESCRIPTION
* add _total to the Prometheus export as required in the spec
* throw an IllegalArgumentException if the metric is a counter and it
  specifies a metric unit other than "none", empty string or null
* change type of gc.%s.time to gauge