### PR TITLE
First cut of Metrics 2.0 support

### DIFF
--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -85,5 +85,13 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.glassfish</groupId>
+      <artifactId>javax.json</artifactId>
+      <version>1.0.4</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 </project>

--- a/implementation/src/main/java/io/smallrye/metrics/ExtendedMetadata.java
+++ b/implementation/src/main/java/io/smallrye/metrics/ExtendedMetadata.java
@@ -16,7 +16,8 @@
  */
 package io.smallrye.metrics;
 
-import org.eclipse.microprofile.metrics.Metadata;
+import java.util.HashMap;
+import org.eclipse.microprofile.metrics.DefaultMetadata;
 import org.eclipse.microprofile.metrics.MetricType;
 
 import java.util.ArrayList;
@@ -26,21 +27,17 @@ import java.util.Map;
 /**
  * @author hrupp
  */
-public class ExtendedMetadata extends Metadata {
+public class ExtendedMetadata extends DefaultMetadata {
 
     private String mbean;
     boolean multi;
 
-    public ExtendedMetadata() {
-        super("-dummy-", MetricType.INVALID);
-    }
-
     public ExtendedMetadata(String name, MetricType type) {
-        super(name, type);
+        this(name,null,null,type,null);
     }
 
     public ExtendedMetadata(String name, String displayName, String description, MetricType typeRaw, String unit) {
-        super(name, displayName, description, typeRaw, unit);
+        super(name, displayName, description, typeRaw, unit,false,new HashMap<>());
     }
 
     public String getMbean() {
@@ -59,11 +56,11 @@ public class ExtendedMetadata extends Metadata {
         this.multi = multi;
     }
 
-    public void setLabels(List<Tag> in) {
-        for (Tag tag : in) {
-            addTag(tag.toKVString());
-        }
-    }
+//    public void setLabels(List<Tag> in) {
+//        for (Tag tag : in) {
+//            addTag(tag.toKVString());
+//        }
+//    }
 
     public List<Tag> getLabels() {
         List<Tag> out = new ArrayList<>(getTags().size());

--- a/implementation/src/main/java/io/smallrye/metrics/JmxWorker.java
+++ b/implementation/src/main/java/io/smallrye/metrics/JmxWorker.java
@@ -17,6 +17,7 @@
 package io.smallrye.metrics;
 
 import org.eclipse.microprofile.metrics.Metadata;
+import org.eclipse.microprofile.metrics.MetricUnits;
 import org.jboss.logging.Logger;
 
 import javax.management.MBeanServer;
@@ -135,9 +136,9 @@ public class JmxWorker {
                         }
                         newName = newName.replace(PLACEHOLDER, keyValue);
                         String newDisplayName = entry.getDisplayName().replace(PLACEHOLDER, keyValue);
-                        String newDescription = entry.getDescription().replace(PLACEHOLDER, keyValue);
+                        String newDescription = entry.getDescription().orElse("%s").replace(PLACEHOLDER, keyValue);
                         ExtendedMetadata newEntry = new ExtendedMetadata(newName, newDisplayName, newDescription,
-                                entry.getTypeRaw(), entry.getUnit());
+                                entry.getTypeRaw(), entry.getUnit().orElse(MetricUnits.NONE));
                         String newObjectName = oName.getCanonicalName() + "/" + attName;
                         newEntry.setMbean(newObjectName);
                         result.add(newEntry);

--- a/implementation/src/main/java/io/smallrye/metrics/MetricProducer.java
+++ b/implementation/src/main/java/io/smallrye/metrics/MetricProducer.java
@@ -20,11 +20,14 @@ package io.smallrye.metrics;
 import io.smallrye.metrics.interceptors.MetricName;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.eclipse.microprofile.metrics.ConcurrentGauge;
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.Gauge;
 import org.eclipse.microprofile.metrics.Histogram;
 import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.Meter;
+import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.MetricType;
 import org.eclipse.microprofile.metrics.MetricUnits;
@@ -56,15 +59,21 @@ public class MetricProducer {
         // A forwarding Gauge must be returned as the Gauge creation happens when the declaring bean gets instantiated and the corresponding Gauge can be injected before which leads to producing a null value
         return () -> {
             // TODO: better error report when the gauge doesn't exist
-            SortedMap<String, Gauge> gauges = applicationRegistry.getGauges();
+            SortedMap<MetricID, Gauge> gauges = applicationRegistry.getGauges();
             String name = metricName.of(ip);
-            return ((Gauge<T>) gauges.get(name)).getValue();
+            MetricID gaugeId = new MetricID(name);
+            return ((Gauge<T>) gauges.get(gaugeId)).getValue();
         };
     }
 
     @Produces
     Counter getCounter(InjectionPoint ip) {
         return this.applicationRegistry.counter(getMetadata(ip, MetricType.COUNTER));
+    }
+
+    @Produces
+    ConcurrentGauge getConcurrentGauge(InjectionPoint ip) {
+        return this.applicationRegistry.concurrentGauge(getMetadata(ip, MetricType.CONCURRENT_GAUGE));
     }
 
     @Produces

--- a/implementation/src/main/java/io/smallrye/metrics/MetricProducer.java
+++ b/implementation/src/main/java/io/smallrye/metrics/MetricProducer.java
@@ -18,6 +18,8 @@
 package io.smallrye.metrics;
 
 import io.smallrye.metrics.interceptors.MetricName;
+import java.util.HashMap;
+import java.util.Map;
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.Gauge;
 import org.eclipse.microprofile.metrics.Histogram;
@@ -25,6 +27,7 @@ import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.Meter;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.MetricType;
+import org.eclipse.microprofile.metrics.MetricUnits;
 import org.eclipse.microprofile.metrics.Timer;
 import org.eclipse.microprofile.metrics.annotation.Metric;
 import org.eclipse.microprofile.metrics.annotation.RegistryType;
@@ -80,23 +83,26 @@ public class MetricProducer {
     }
 
     private Metadata getMetadata(InjectionPoint ip, MetricType type) {
-        Metadata metadata = new OriginTrackedMetadata(ip, metricName.of(ip), type);
         Metric metric = ip.getAnnotated().getAnnotation(Metric.class);
-        if (metric != null) {
-            if (!metric.unit().isEmpty()) {
-                metadata.setUnit(metric.unit());
-            }
-            if (!metric.description().isEmpty()) {
-                metadata.setDescription(metric.description());
-            }
-            if (!metric.displayName().isEmpty()) {
-                metadata.setDisplayName(metric.displayName());
-            }
+        Metadata metadata;
+        if (metric!= null) {
+            Map<String, String> tagMap = new HashMap<>();
             if (metric.tags().length > 0) {
                 for (String tag : metric.tags()) {
-                    metadata.addTags(tag);
+                    Tag t = new Tag(tag);
+                    tagMap.put(t.getKey(),t.getValue());
                 }
             }
+
+            metadata = new OriginTrackedMetadata(ip, metricName.of(ip), type, metric.unit(), metric.description(),
+                                                 metric.displayName(),
+                                                 false, tagMap);
+        } else {
+            metadata = new OriginTrackedMetadata(ip, metricName.of(ip), type, MetricUnits.NONE, "", "", false,
+                                                 new HashMap<>(1));
+        }
+
+        if (metric != null) {
         }
         return metadata;
     }

--- a/implementation/src/main/java/io/smallrye/metrics/MetricsRegistryImpl.java
+++ b/implementation/src/main/java/io/smallrye/metrics/MetricsRegistryImpl.java
@@ -23,7 +23,6 @@ import io.smallrye.metrics.app.HistogramImpl;
 import io.smallrye.metrics.app.MeterImpl;
 import io.smallrye.metrics.app.TimerImpl;
 
-import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import org.eclipse.microprofile.config.Config;
@@ -160,7 +159,10 @@ public class MetricsRegistryImpl extends MetricRegistry {
         return metric;
     }
 
-
+    @Override
+    public <T extends Metric> T register(Metadata metadata, T metric, org.eclipse.microprofile.metrics.Tag... tags) throws IllegalArgumentException {
+        return null;  // TODO: Customise this generated block
+    }
 
     protected Metadata duplicate(Metadata meta) {
         Metadata copy = null;
@@ -209,6 +211,16 @@ public class MetricsRegistryImpl extends MetricRegistry {
     }
 
     @Override
+    public Counter counter(String name, org.eclipse.microprofile.metrics.Tag... tags) {
+        return null;  // TODO: Customise this generated block
+    }
+
+    @Override
+    public Counter counter(Metadata metadata, org.eclipse.microprofile.metrics.Tag... tags) {
+        return null;  // TODO: Customise this generated block
+    }
+
+    @Override
     public org.eclipse.microprofile.metrics.Counter counter(Metadata metadata) {
         return get(metadata, MetricType.COUNTER);
     }
@@ -224,6 +236,16 @@ public class MetricsRegistryImpl extends MetricRegistry {
     }
 
     @Override
+    public ConcurrentGauge concurrentGauge(String name, org.eclipse.microprofile.metrics.Tag... tags) {
+        return null;  // TODO: Customise this generated block
+    }
+
+    @Override
+    public ConcurrentGauge concurrentGauge(Metadata metadata, org.eclipse.microprofile.metrics.Tag... tags) {
+        return null;  // TODO: Customise this generated block
+    }
+
+    @Override
     public Histogram histogram(String name) {
         return histogram(Metadata.builder().withName(name).withType(MetricType.HISTOGRAM).build());
     }
@@ -234,6 +256,16 @@ public class MetricsRegistryImpl extends MetricRegistry {
     }
 
     @Override
+    public Histogram histogram(String name, org.eclipse.microprofile.metrics.Tag... tags) {
+        return null;  // TODO: Customise this generated block
+    }
+
+    @Override
+    public Histogram histogram(Metadata metadata, org.eclipse.microprofile.metrics.Tag... tags) {
+        return null;  // TODO: Customise this generated block
+    }
+
+    @Override
     public Meter meter(String s) {
         return meter(Metadata.builder().withName(s).withType(MetricType.METERED).build());
     }
@@ -241,6 +273,16 @@ public class MetricsRegistryImpl extends MetricRegistry {
     @Override
     public Meter meter(Metadata metadata) {
         return get(metadata, MetricType.METERED);
+    }
+
+    @Override
+    public Meter meter(String name, org.eclipse.microprofile.metrics.Tag... tags) {
+        return null;  // TODO: Customise this generated block
+    }
+
+    @Override
+    public Meter meter(Metadata metadata, org.eclipse.microprofile.metrics.Tag... tags) {
+        return null;  // TODO: Customise this generated block
     }
 
     private <T extends Metric> T get(Metadata metadata, MetricType type) {
@@ -323,11 +365,33 @@ public class MetricsRegistryImpl extends MetricRegistry {
     }
 
     @Override
+    public Timer timer(String name, org.eclipse.microprofile.metrics.Tag... tags) {
+        return null;  // TODO: Customise this generated block
+    }
+
+    @Override
+    public Timer timer(Metadata metadata, org.eclipse.microprofile.metrics.Tag... tags) {
+        return null;  // TODO: Customise this generated block
+    }
+
+    @Override
     public boolean remove(String metricName) {
-        if (metricMap.containsKey(metricName)) {
+        MetricID idToRemove = new MetricID(metricName);
+        if (metricMap.containsKey(idToRemove)) {
             log.debugf("Remove metric [name: %s]", metricName);
-            metricMap.remove(metricName);
+            metricMap.remove(idToRemove);
             metadataMap.remove(metricName);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean remove(MetricID metricID) {
+        if (metricMap.containsKey(metricID)) {
+            log.debugf("Remove metric [id: %s]", metricID);
+            metricMap.remove(metricID);
+            metadataMap.remove(metricID.getName());
             return true;
         }
         return false;
@@ -351,7 +415,12 @@ public class MetricsRegistryImpl extends MetricRegistry {
             out.add(id.getName());
         }
         return out;
-}
+    }
+
+    @Override
+    public SortedSet<MetricID> getMetricIDs() {
+        return new TreeSet<>(metricMap.keySet());
+    }
 
     @Override
     public SortedMap<MetricID, Gauge> getGauges() {

--- a/implementation/src/main/java/io/smallrye/metrics/OriginTrackedMetadata.java
+++ b/implementation/src/main/java/io/smallrye/metrics/OriginTrackedMetadata.java
@@ -1,14 +1,17 @@
 package io.smallrye.metrics;
 
-import org.eclipse.microprofile.metrics.Metadata;
+import java.util.HashMap;
+import java.util.Map;
+import org.eclipse.microprofile.metrics.DefaultMetadata;
 import org.eclipse.microprofile.metrics.MetricType;
 
 /**
  * Created by bob on 2/5/18.
  */
-public class OriginTrackedMetadata extends Metadata {
-    public OriginTrackedMetadata(Object origin, String name, MetricType type) {
-        super(name, type);
+public class OriginTrackedMetadata extends DefaultMetadata {
+    public OriginTrackedMetadata(Object origin, String name, MetricType type, String unit, String description, String displayName, boolean reusable, Map<String,String> tagMap) {
+
+        super(name, displayName, description, type,unit, reusable, tagMap);
         this.origin = origin;
     }
 

--- a/implementation/src/main/java/io/smallrye/metrics/app/ConcurrentGaugeImpl.java
+++ b/implementation/src/main/java/io/smallrye/metrics/app/ConcurrentGaugeImpl.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * *******************************************************************************
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.metrics.app;
+
+import org.eclipse.microprofile.metrics.ConcurrentGauge;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * @author Jan Martiska
+ */
+public class ConcurrentGaugeImpl implements ConcurrentGauge {
+
+    // current count of concurrent invocations
+    private final AtomicLong count;
+
+    // maximum count achieved in previous minute
+    private final AtomicLong max_previousMinute;
+    // minimum count achieved in previous minute
+    private final AtomicLong min_previousMinute;
+
+    // maximum count achieved in this minute
+    private final AtomicLong max_thisMinute;
+    // minimum count achieved in this minute
+    private final AtomicLong min_thisMinute;
+
+    // current timestamp rounded down to the last whole minute
+    private final AtomicLong thisMinute;
+
+    public ConcurrentGaugeImpl() {
+        count = new AtomicLong(0);
+        max_previousMinute = new AtomicLong(0);
+        min_previousMinute = new AtomicLong(0);
+        max_thisMinute = new AtomicLong(0);
+        min_thisMinute = new AtomicLong(0);
+        thisMinute = new AtomicLong(getCurrentMinuteFromSystem());
+    }
+
+    @Override
+    public void inc() {
+        maybeStartNewMinute();
+        synchronized (this) {
+            long newCount = count.incrementAndGet();
+            if(newCount > max_thisMinute.get()) {
+                max_thisMinute.set(newCount);
+            }
+        }
+    }
+
+    @Override
+    public void dec() {
+        maybeStartNewMinute();
+        synchronized (this) {
+            long newCount = count.decrementAndGet();
+            if(newCount < min_thisMinute.get()) {
+                min_thisMinute.set(newCount);
+            }
+        }
+    }
+
+    @Override
+    public long getCount() {
+        maybeStartNewMinute();
+        return count.get();
+    }
+
+    @Override
+    public long getMax() {
+        maybeStartNewMinute();
+        return max_previousMinute.get();
+    }
+
+    @Override
+    public long getMin() {
+        maybeStartNewMinute();
+        return min_previousMinute.get();
+    }
+
+    /* If a new minute has started, move the data for 'this' minute to 'previous' minute and start
+       collecting new data for the 'this' minute */
+    private void maybeStartNewMinute() {
+        long newMinute = getCurrentMinuteFromSystem();
+        if(newMinute > thisMinute.get()) {
+            synchronized (this) {
+                if (newMinute > thisMinute.get()) {
+                    thisMinute.set(newMinute);
+                    max_previousMinute.set(max_thisMinute.get());
+                    min_previousMinute.set(min_thisMinute.get());
+                    max_thisMinute.set(count.get());
+                    min_thisMinute.set(count.get());
+                }
+            }
+        }
+    }
+
+    // Get the current system time in minutes, truncating. This number will increase by 1 every complete minute.
+    private long getCurrentMinuteFromSystem() {
+        return System.currentTimeMillis() / 60000;
+    }
+}

--- a/implementation/src/main/java/io/smallrye/metrics/app/CounterImpl.java
+++ b/implementation/src/main/java/io/smallrye/metrics/app/CounterImpl.java
@@ -57,16 +57,6 @@ public class CounterImpl implements Counter {
     }
 
     @Override
-    public void dec() {
-        count.decrement();
-    }
-
-    @Override
-    public void dec(long n) {
-        count.add(-n);
-    }
-
-    @Override
     public long getCount() {
         return count.sum();
     }

--- a/implementation/src/main/java/io/smallrye/metrics/exporters/JsonExporter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/exporters/JsonExporter.java
@@ -18,16 +18,15 @@
 package io.smallrye.metrics.exporters;
 
 import io.smallrye.metrics.MetricRegistries;
-import io.smallrye.metrics.app.HistogramImpl;
-import io.smallrye.metrics.app.MeterImpl;
-import io.smallrye.metrics.app.TimerImpl;
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.Gauge;
+import org.eclipse.microprofile.metrics.Histogram;
 import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.Metered;
 import org.eclipse.microprofile.metrics.Metric;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.Snapshot;
+import org.eclipse.microprofile.metrics.Timer;
 import org.jboss.logging.Logger;
 
 import java.util.HashMap;
@@ -99,19 +98,19 @@ public class JsonExporter implements Exporter {
                         metricBuffer.append("  ").append('"').append(key).append('"').append(" : ").append(val);
                         break;
                     case METERED:
-                        MeterImpl meter = (MeterImpl) value;
+                        Metered meter = (Metered) value;
                         writeStartLine(metricBuffer, key);
                         writeMeterValues(metricBuffer, meter);
                         writeEndLine(metricBuffer);
                         break;
                     case TIMER:
-                        TimerImpl timer = (TimerImpl) value;
+                        Timer timer = (Timer) value;
                         writeStartLine(metricBuffer, key);
                         writeTimerValues(metricBuffer, timer, metadata.getUnit());
                         writeEndLine(metricBuffer);
                         break;
                     case HISTOGRAM:
-                        HistogramImpl hist = (HistogramImpl) value;
+                        Histogram hist = (Histogram) value;
                         writeStartLine(metricBuffer, key);
                         metricBuffer.append("    \"count\": ").append(hist.getCount()).append(COMMA_LF);
                         writeSnapshotValues(metricBuffer, hist.getSnapshot());
@@ -144,12 +143,12 @@ public class JsonExporter implements Exporter {
         sb.append("    \"fifteenMinRate\": ").append(meter.getFifteenMinuteRate()).append(LF);
     }
 
-    private void writeTimerValues(StringBuffer sb, TimerImpl timer, String unit) {
+    private void writeTimerValues(StringBuffer sb, Timer timer, String unit) {
         writeSnapshotValues(sb, timer.getSnapshot(), unit);
         // Backup and write COMMA_LF
         sb.setLength(sb.length() - 1);
         sb.append(COMMA_LF);
-        writeMeterValues(sb, timer.getMeter());
+        writeMeterValues(sb, timer);
     }
 
     private void writeSnapshotValues(StringBuffer sb, Snapshot snapshot) {

--- a/implementation/src/main/java/io/smallrye/metrics/exporters/JsonExporter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/exporters/JsonExporter.java
@@ -80,7 +80,6 @@ public class JsonExporter implements Exporter {
             if (metadata == null) {
                 throw new IllegalArgumentException("MD is null for " + key);
             }
-
             StringBuffer metricBuffer = new StringBuffer();
 
 
@@ -106,7 +105,7 @@ public class JsonExporter implements Exporter {
                     case TIMER:
                         Timer timer = (Timer) value;
                         writeStartLine(metricBuffer, key);
-                        writeTimerValues(metricBuffer, timer, metadata.getUnit());
+                        writeTimerValues(metricBuffer, timer, metadata.getUnit().get());
                         writeEndLine(metricBuffer);
                         break;
                     case HISTOGRAM:

--- a/implementation/src/main/java/io/smallrye/metrics/exporters/JsonExporter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/exporters/JsonExporter.java
@@ -18,12 +18,14 @@
 package io.smallrye.metrics.exporters;
 
 import io.smallrye.metrics.MetricRegistries;
+import org.eclipse.microprofile.metrics.ConcurrentGauge;
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.Gauge;
 import org.eclipse.microprofile.metrics.Histogram;
 import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.Metered;
 import org.eclipse.microprofile.metrics.Metric;
+import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.Snapshot;
 import org.eclipse.microprofile.metrics.Timer;
@@ -56,7 +58,7 @@ public class JsonExporter implements Exporter {
     private void getMetricsForAScope(StringBuffer sb, MetricRegistry.Type scope) {
 
         MetricRegistry registry = MetricRegistries.get(scope);
-        Map<String, Metric> metricMap = registry.getMetrics();
+        Map<MetricID, Metric> metricMap = registry.getMetrics();
         Map<String, Metadata> metadataMap = registry.getMetadata();
 
         sb.append("{\n");
@@ -66,13 +68,13 @@ public class JsonExporter implements Exporter {
         sb.append(LF).append("}");
     }
 
-    private void writeMetricsForMap(StringBuffer sb, Map<String, Metric> metricMap, Map<String, Metadata> metadataMap) {
+    private void writeMetricsForMap(StringBuffer sb, Map<MetricID, Metric> metricMap, Map<String, Metadata> metadataMap) {
 
         boolean first = true;
 
-        for (Iterator<Map.Entry<String, Metric>> iterator = metricMap.entrySet().iterator(); iterator.hasNext(); ) {
-            Map.Entry<String, Metric> entry = iterator.next();
-            String key = entry.getKey();
+        for (Iterator<Map.Entry<MetricID, Metric>> iterator = metricMap.entrySet().iterator(); iterator.hasNext(); ) {
+            Map.Entry<MetricID, Metric> entry = iterator.next();
+            String key = entry.getKey().getName();
 
             Metric value = entry.getValue();
             Metadata metadata = metadataMap.get(key);
@@ -81,7 +83,6 @@ public class JsonExporter implements Exporter {
                 throw new IllegalArgumentException("MD is null for " + key);
             }
             StringBuffer metricBuffer = new StringBuffer();
-
 
             if (first) {
                 first = false;
@@ -101,6 +102,12 @@ public class JsonExporter implements Exporter {
                         writeStartLine(metricBuffer, key);
                         writeMeterValues(metricBuffer, meter);
                         writeEndLine(metricBuffer);
+                        break;
+                    case CONCURRENT_GAUGE:
+                        ConcurrentGauge gauge = (ConcurrentGauge) value;
+                        writeStartLine(sb, key);
+                        writeConcurrentGaugeValues(sb, gauge);
+                        writeEndLine(sb);
                         break;
                     case TIMER:
                         Timer timer = (Timer) value;
@@ -132,6 +139,12 @@ public class JsonExporter implements Exporter {
 
     private void writeStartLine(StringBuffer sb, String key) {
         sb.append("  ").append('"').append(key).append('"').append(" : ").append("{\n");
+    }
+
+    private void writeConcurrentGaugeValues(StringBuffer sb, ConcurrentGauge concurrentGauge) {
+        sb.append("    \"callCount\": ").append(concurrentGauge.getCount()).append(COMMA_LF);
+        sb.append("    \"max\": ").append(concurrentGauge.getMax()).append(COMMA_LF);
+        sb.append("    \"min\": ").append(concurrentGauge.getMin()).append(LF);
     }
 
     private void writeMeterValues(StringBuffer sb, Metered meter) {
@@ -227,14 +240,15 @@ public class JsonExporter implements Exporter {
     @Override
     public StringBuffer exportOneMetric(MetricRegistry.Type scope, String metricName) {
         MetricRegistry registry = MetricRegistries.get(scope);
-        Map<String, Metric> metricMap = registry.getMetrics();
+        Map<MetricID, Metric> metricMap = registry.getMetrics();
         Map<String, Metadata> metadataMap = registry.getMetadata();
 
 
         Metric m = metricMap.get(metricName);
 
-        Map<String, Metric> outMap = new HashMap<>(1);
-        outMap.put(metricName, m);
+        Map<MetricID, Metric> outMap = new HashMap<>(1);
+        MetricID outId = new MetricID(metricName);
+        outMap.put(outId, m);
 
         StringBuffer sb = new StringBuffer();
         sb.append("{");

--- a/implementation/src/main/java/io/smallrye/metrics/exporters/JsonMetadataExporter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/exporters/JsonMetadataExporter.java
@@ -116,14 +116,14 @@ public class JsonMetadataExporter implements Exporter {
     private JsonObject metricJSON(Metadata metadata) {
         JsonObjectBuilder obj = Json.createObjectBuilder();
 
-        if (metadata.getUnit() != null) {
-            obj.add("unit", metadata.getUnit());
+        if (metadata.getUnit().isPresent()) {
+            obj.add("unit", metadata.getUnit().get());
         }
         if (metadata.getType() != null) {
             obj.add("type", metadata.getType());
         }
-        if (metadata.getDescription() != null) {
-            obj.add("description", metadata.getDescription());
+        if (metadata.getDescription().isPresent()) {
+            obj.add("description", metadata.getDescription().get());
         }
         if (metadata.getDisplayName() != null) {
             obj.add("displayName", metadata.getDisplayName());

--- a/implementation/src/main/java/io/smallrye/metrics/exporters/PrometheusExporter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/exporters/PrometheusExporter.java
@@ -305,12 +305,7 @@ public class PrometheusExporter implements Exporter {
         // Only write this line if we actually have a description in metadata
         if (writeHelpLine && md.getDescription().isPresent()) {
             sb.append("# HELP ");
-            sb.append(scope.getName().toLowerCase());
-            sb.append(':').append(getPrometheusMetricName(key));
-            if (suffix != null) {
-                sb.append(suffix);
-            }
-            sb.append(SPACE);
+            getNameWithScopeAndSuffix(sb, scope, key, suffix);
             sb.append(md.getDescription().get());
             sb.append(LF);
         }
@@ -319,12 +314,7 @@ public class PrometheusExporter implements Exporter {
 
     private void writeTypeLine(StringBuffer sb, MetricRegistry.Type scope, String key, Metadata md, String suffix, String typeOverride) {
         sb.append("# TYPE ");
-        sb.append(scope.getName().toLowerCase());
-        sb.append(':').append(getPrometheusMetricName(key));
-        if (suffix != null) {
-            sb.append(suffix);
-        }
-        sb.append(SPACE);
+        getNameWithScopeAndSuffix(sb, scope, key, suffix);
         if (typeOverride != null) {
             sb.append(typeOverride);
         } else if (md.getTypeRaw().equals(MetricType.TIMER)) {
@@ -335,6 +325,15 @@ public class PrometheusExporter implements Exporter {
             sb.append(md.getType());
         }
         sb.append(LF);
+    }
+
+    private void getNameWithScopeAndSuffix(StringBuffer sb, MetricRegistry.Type scope, String key, String suffix) {
+        sb.append(scope.getName().toLowerCase());
+        sb.append('_').append(getPrometheusMetricName(key));
+        if (suffix != null) {
+            sb.append(suffix);
+        }
+        sb.append(SPACE);
     }
 
     private void createSimpleValueLine(StringBuffer sb, MetricRegistry.Type scope, String key, Metadata md, Metric metric) {

--- a/implementation/src/main/java/io/smallrye/metrics/exporters/PrometheusExporter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/exporters/PrometheusExporter.java
@@ -21,12 +21,14 @@ import io.smallrye.metrics.MetricRegistries;
 import io.smallrye.metrics.Tag;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.metrics.ConcurrentGauge;
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.Gauge;
 import org.eclipse.microprofile.metrics.Histogram;
 import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.Metered;
 import org.eclipse.microprofile.metrics.Metric;
+import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.MetricType;
 import org.eclipse.microprofile.metrics.MetricUnits;
@@ -94,12 +96,13 @@ public class PrometheusExporter implements Exporter {
     @Override
     public StringBuffer exportOneMetric(MetricRegistry.Type scope, String metricName) {
         MetricRegistry registry = MetricRegistries.get(scope);
-        Map<String, Metric> metricMap = registry.getMetrics();
+        Map<MetricID, Metric> metricMap = registry.getMetrics();
 
         Metric m = metricMap.get(metricName);
 
-        Map<String, Metric> outMap = new HashMap<>(1);
-        outMap.put(metricName, m);
+        Map<MetricID, Metric> outMap = new HashMap<>(1);
+        MetricID outName = new MetricID(metricName);
+        outMap.put(outName, m);
 
         StringBuffer sb = new StringBuffer();
         exposeEntries(scope, sb, registry, outMap);
@@ -114,14 +117,15 @@ public class PrometheusExporter implements Exporter {
 
     private void getEntriesForScope(MetricRegistry.Type scope, StringBuffer sb) {
         MetricRegistry registry = MetricRegistries.get(scope);
-        Map<String, Metric> metricMap = registry.getMetrics();
+        Map<MetricID, Metric> metricMap = registry.getMetrics();
 
         exposeEntries(scope, sb, registry, metricMap);
     }
 
-    private void exposeEntries(MetricRegistry.Type scope, StringBuffer sb, MetricRegistry registry, Map<String, Metric> metricMap) {
-        for (Map.Entry<String, Metric> entry : metricMap.entrySet()) {
-            String key = entry.getKey();
+    private void exposeEntries(MetricRegistry.Type scope, StringBuffer sb, MetricRegistry registry,
+                               Map<MetricID, Metric> metricMap) {
+        for (Map.Entry<MetricID, Metric> entry : metricMap.entrySet()) {
+            String key = entry.getKey().getName();
             Metadata md = registry.getMetadata().get(key);
 
             if (md == null) {
@@ -144,6 +148,10 @@ public class PrometheusExporter implements Exporter {
                         writeHelpLine(metricBuf, scope, key, md, suffix);
                         writeTypeLine(metricBuf, scope, key, md, suffix, null);
                         createSimpleValueLine(metricBuf, scope, key, md, metric);
+                        break;
+                    case CONCURRENT_GAUGE:
+                        ConcurrentGauge concurrentGauge = (ConcurrentGauge) metric;
+                        writeConcurrentGaugeValues(sb, scope, concurrentGauge, md, key);
                         break;
                     case METERED:
                         Metered meter = (Metered) metric;
@@ -183,6 +191,14 @@ public class PrometheusExporter implements Exporter {
         writeValueLine(sb,scope,suffix + "_count",timer.getCount(),md, null, false);
 
         writeSnapshotQuantiles(sb, scope, md, snapshot, theUnit, true);
+    }
+
+    private void writeConcurrentGaugeValues(StringBuffer sb, MetricRegistry.Type scope, ConcurrentGauge concurrentGauge, Metadata md, String key) {
+        key = getPrometheusMetricName(key);
+        writeHelpLine(sb, scope, key, md, "_current");
+        writeTypeAndValue(sb, scope, "_current", concurrentGauge.getCount(), GAUGE, md, false);
+        writeTypeAndValue(sb, scope, "_max", concurrentGauge.getMax(), GAUGE, md, false);
+        writeTypeAndValue(sb, scope, "_min", concurrentGauge.getMin(), GAUGE, md, false);
     }
 
     private void writeHistogramValues(StringBuffer sb, MetricRegistry.Type scope, Histogram histogram, Metadata md) {
@@ -260,7 +276,7 @@ public class PrometheusExporter implements Exporter {
         }
         // add tags
 
-        Map<String, String> tags = new HashMap<>(md.getTags());
+        Map<String, String> tags = new HashMap<>(); // TODO new HashMap<>(md.getTags());
         if (extraTag != null) {
             tags.put(extraTag.getKey(), extraTag.getValue());
         }
@@ -275,7 +291,7 @@ public class PrometheusExporter implements Exporter {
             String scaleFrom = "nanoseconds";
             if(md.getTypeRaw() == MetricType.HISTOGRAM)
                 // for histograms, internally the data is stored using the metric's unit
-                scaleFrom = md.getUnit();
+                scaleFrom = md.getUnit().orElse(NONE);
             value = PrometheusUnit.scaleToBase(scaleFrom, valueRaw);
         } else {
             value = valueRaw;
@@ -344,7 +360,7 @@ public class PrometheusExporter implements Exporter {
         if (!unit.equals(NONE)) {
             sb.append(USCORE).append(unit);
         }
-        String tags = md.getTagsAsString();
+        String tags = null; // TODO md.getTagsAsString();
         if (tags != null && !tags.isEmpty()) {
             sb.append('{').append(tags).append('}');
         }

--- a/implementation/src/main/java/io/smallrye/metrics/exporters/PrometheusExporter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/exporters/PrometheusExporter.java
@@ -19,13 +19,11 @@ package io.smallrye.metrics.exporters;
 
 import io.smallrye.metrics.MetricRegistries;
 import io.smallrye.metrics.Tag;
-import io.smallrye.metrics.app.HistogramImpl;
-import io.smallrye.metrics.app.MeterImpl;
-import io.smallrye.metrics.app.TimerImpl;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.Gauge;
+import org.eclipse.microprofile.metrics.Histogram;
 import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.Metered;
 import org.eclipse.microprofile.metrics.Metric;
@@ -33,6 +31,7 @@ import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.MetricType;
 import org.eclipse.microprofile.metrics.MetricUnits;
 import org.eclipse.microprofile.metrics.Snapshot;
+import org.eclipse.microprofile.metrics.Timer;
 import org.jboss.logging.Logger;
 
 import java.util.HashMap;
@@ -146,15 +145,15 @@ public class PrometheusExporter implements Exporter {
                         createSimpleValueLine(metricBuf, scope, key, md, metric);
                         break;
                     case METERED:
-                        MeterImpl meter = (MeterImpl) metric;
+                        Metered meter = (Metered) metric;
                         writeMeterValues(metricBuf, scope, meter, md);
                         break;
                     case TIMER:
-                        TimerImpl timer = (TimerImpl) metric;
+                        Timer timer = (Timer) metric;
                         writeTimerValues(metricBuf, scope, timer, md);
                         break;
                     case HISTOGRAM:
-                        HistogramImpl histogram = (HistogramImpl) metric;
+                        Histogram histogram = (Histogram) metric;
                         writeHistogramValues(metricBuf, scope, histogram, md);
                         break;
                     default:
@@ -167,14 +166,14 @@ public class PrometheusExporter implements Exporter {
         }
     }
 
-    private void writeTimerValues(StringBuffer sb, MetricRegistry.Type scope, TimerImpl timer, Metadata md) {
+    private void writeTimerValues(StringBuffer sb, MetricRegistry.Type scope, Timer timer, Metadata md) {
 
         String unit = md.getUnit();
         unit = PrometheusUnit.getBaseUnitAsPrometheusString(unit);
 
         String theUnit = unit.equals("none") ? "" : USCORE + unit;
 
-        writeMeterRateValues(sb, scope, timer.getMeter(), md);
+        writeMeterRateValues(sb, scope, timer, md);
         Snapshot snapshot = timer.getSnapshot();
         writeSnapshotBasics(sb, scope, md, snapshot, theUnit, true);
 
@@ -186,7 +185,7 @@ public class PrometheusExporter implements Exporter {
         writeSnapshotQuantiles(sb, scope, md, snapshot, theUnit, true);
     }
 
-    private void writeHistogramValues(StringBuffer sb, MetricRegistry.Type scope, HistogramImpl histogram, Metadata md) {
+    private void writeHistogramValues(StringBuffer sb, MetricRegistry.Type scope, Histogram histogram, Metadata md) {
 
         Snapshot snapshot = histogram.getSnapshot();
         String unit = md.getUnit();

--- a/implementation/src/main/java/io/smallrye/metrics/exporters/PrometheusUnit.java
+++ b/implementation/src/main/java/io/smallrye/metrics/exporters/PrometheusUnit.java
@@ -24,6 +24,7 @@ import static io.smallrye.metrics.exporters.ExporterUtil.NANOS_PER_MILLI;
 import static io.smallrye.metrics.exporters.ExporterUtil.NANOS_PER_MINUTE;
 import static io.smallrye.metrics.exporters.ExporterUtil.NANOS_PER_SECOND;
 
+import java.util.Optional;
 import org.eclipse.microprofile.metrics.MetricUnits;
 
 /**
@@ -43,7 +44,13 @@ public class PrometheusUnit {
      * - for time units, returns "seconds"
      * - for any other unit, returns the input unit itself
      */
-    public static String getBaseUnitAsPrometheusString(String unit) {
+    public static String getBaseUnitAsPrometheusString(Optional<String> optUnit) {
+
+        if (!optUnit.isPresent()) {
+            return "NONE";
+        }
+
+        String unit = optUnit.get();
 
         String out;
         switch (unit) {

--- a/implementation/src/main/java/io/smallrye/metrics/exporters/PrometheusUnit.java
+++ b/implementation/src/main/java/io/smallrye/metrics/exporters/PrometheusUnit.java
@@ -36,6 +36,13 @@ public class PrometheusUnit {
     }
 
 
+    /**
+     * Determines the basic unit to be used by Prometheus exporter based on the input unit from parameter.
+     * That is:
+     * - for memory size units, returns "bytes"
+     * - for time units, returns "seconds"
+     * - for any other unit, returns the input unit itself
+     */
     public static String getBaseUnitAsPrometheusString(String unit) {
 
         String out;
@@ -88,11 +95,18 @@ public class PrometheusUnit {
         return out;
     }
 
-    public static Double scaleToBase(String unit, Double value) {
+    /**
+     * Scales the value (time or memory size) interpreted using inputUnit to the base unit for Prometheus exporter
+     * That means:
+     * - values for memory size units are scaled to bytes
+     * - values for time units are scaled to seconds
+     * - values for other units are returned unchanged
+     */
+    public static Double scaleToBase(String inputUnit, Double value) {
 
         Double out;
 
-        switch (unit) {
+        switch (inputUnit) {
 
             case MetricUnits.BITS:
                 out = value / 8;

--- a/implementation/src/main/java/io/smallrye/metrics/interceptors/MetricResolver.java
+++ b/implementation/src/main/java/io/smallrye/metrics/interceptors/MetricResolver.java
@@ -17,10 +17,7 @@
 package io.smallrye.metrics.interceptors;
 
 import org.eclipse.microprofile.metrics.MetricRegistry;
-import org.eclipse.microprofile.metrics.annotation.Counted;
-import org.eclipse.microprofile.metrics.annotation.Gauge;
-import org.eclipse.microprofile.metrics.annotation.Metered;
-import org.eclipse.microprofile.metrics.annotation.Timed;
+import org.eclipse.microprofile.metrics.annotation.*;
 
 import javax.enterprise.inject.Vetoed;
 import java.lang.annotation.Annotation;
@@ -39,6 +36,10 @@ public class MetricResolver {
 
     public <E extends Member & AnnotatedElement> Of<Counted> counted(Class<?> topClass, E element) {
         return resolverOf(topClass, element, Counted.class);
+    }
+
+    public <E extends Member & AnnotatedElement> Of<ConcurrentGauge> concurrentGauge(Class<?> topClass, E element) {
+        return resolverOf(topClass, element, ConcurrentGauge.class);
     }
 
     public Of<Gauge> gauge(Class<?> topClass, Method method) {
@@ -109,6 +110,8 @@ public class MetricResolver {
     private String metricName(Annotation annotation) {
         if (Counted.class.isInstance(annotation)) {
             return ((Counted) annotation).name();
+        } else if (ConcurrentGauge.class.isInstance(annotation)) {
+            return ((ConcurrentGauge) annotation).name();
         } else if (Gauge.class.isInstance(annotation)) {
             return ((Gauge) annotation).name();
         } else if (Metered.class.isInstance(annotation)) {
@@ -129,6 +132,8 @@ public class MetricResolver {
 
         if (Counted.class.isInstance(annotation)) {
             return ((Counted) annotation).absolute();
+        } else if (ConcurrentGauge.class.isInstance(annotation)) {
+            return ((ConcurrentGauge) annotation).absolute();
         } else if (Gauge.class.isInstance(annotation)) {
             return ((Gauge) annotation).absolute();
         } else if (Metered.class.isInstance(annotation)) {

--- a/implementation/src/main/java/io/smallrye/metrics/mbean/MCounterImpl.java
+++ b/implementation/src/main/java/io/smallrye/metrics/mbean/MCounterImpl.java
@@ -45,16 +45,6 @@ public class MCounterImpl implements Counter {
     }
 
     @Override
-    public void dec() {
-        throw new IllegalStateException(MUST_NOT_BE_CALLED);
-    }
-
-    @Override
-    public void dec(long n) {
-        throw new IllegalStateException(MUST_NOT_BE_CALLED);
-    }
-
-    @Override
     public long getCount() {
         return worker.getValue(mbeanExpression).longValue();
     }

--- a/implementation/src/main/java/io/smallrye/metrics/setup/JmxRegistrar.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/JmxRegistrar.java
@@ -75,7 +75,7 @@ public class JmxRegistrar {
         Properties baseMetricsProps = new Properties();
         baseMetricsProps.load(propertiesResource);
 
-        Map<String, List<MetricProperty>> parsedMetrics = baseMetricsProps.entrySet() 
+        Map<String, List<MetricProperty>> parsedMetrics = baseMetricsProps.entrySet()
                 .stream()
                 .map(MetricProperty::new)
                 .collect(Collectors.groupingBy(MetricProperty::getMetricName));
@@ -102,11 +102,11 @@ public class JmxRegistrar {
                 .forEach(
                         prop -> entryProperties.put(prop.propertyKey, prop.propertyValue)
                 );
-        ExtendedMetadata meta = new ExtendedMetadata(name, metricTypeOf(entryProperties.get("type")));
+        ExtendedMetadata meta = new ExtendedMetadata(name, entryProperties.get("displayName"),
+                                                     entryProperties.get("description"),
+                                                     metricTypeOf(entryProperties.get("type")),entryProperties.get(
+                                                         "unit"));
         meta.setMbean(entryProperties.get("mbean"));
-        meta.setDisplayName(entryProperties.get("displayName"));
-        meta.setDescription(entryProperties.get("description"));
-        meta.setUnit(entryProperties.get("unit"));
         meta.setMulti("true".equalsIgnoreCase(entryProperties.get("multi")));
         return meta;
     }

--- a/implementation/src/main/java/io/smallrye/metrics/setup/MetricCdiInjectionExtension.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/MetricCdiInjectionExtension.java
@@ -20,6 +20,7 @@ package io.smallrye.metrics.setup;
 import io.smallrye.metrics.MetricProducer;
 import io.smallrye.metrics.MetricRegistries;
 import io.smallrye.metrics.MetricsRequestHandler;
+import io.smallrye.metrics.interceptors.ConcurrentGaugeInterceptor;
 import io.smallrye.metrics.interceptors.CountedInterceptor;
 import io.smallrye.metrics.interceptors.MeteredInterceptor;
 import io.smallrye.metrics.interceptors.MetricName;
@@ -30,6 +31,7 @@ import io.smallrye.metrics.interceptors.MetricsInterceptor;
 import io.smallrye.metrics.interceptors.TimedInterceptor;
 import org.eclipse.microprofile.metrics.Metric;
 import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.annotation.ConcurrentGauge;
 import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Gauge;
 import org.eclipse.microprofile.metrics.annotation.Metered;
@@ -96,6 +98,7 @@ public class MetricCdiInjectionExtension implements Extension {
 
                 MeteredInterceptor.class,
                 CountedInterceptor.class,
+                ConcurrentGaugeInterceptor.class,
                 TimedInterceptor.class,
                 MetricsRequestHandler.class
         }) {
@@ -103,7 +106,7 @@ public class MetricCdiInjectionExtension implements Extension {
         }
     }
 
-    private <X> void metricsAnnotations(@Observes @WithAnnotations({ Counted.class, Gauge.class, Metered.class, Timed.class }) ProcessAnnotatedType<X> pat) {
+    private <X> void metricsAnnotations(@Observes @WithAnnotations({ Counted.class, Gauge.class, Metered.class, Timed.class, ConcurrentGauge.class}) ProcessAnnotatedType<X> pat) {
         Class<X> clazz = pat.getAnnotatedType().getJavaClass();
         Package pack = clazz.getPackage();
         if (pack != null && pack.getName().equals(MetricsInterceptor.class.getPackage().getName())) {

--- a/implementation/src/main/java/io/smallrye/metrics/setup/MetricsMetadata.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/MetricsMetadata.java
@@ -18,7 +18,10 @@
 package io.smallrye.metrics.setup;
 
 import io.smallrye.metrics.OriginTrackedMetadata;
+import io.smallrye.metrics.Tag;
 import io.smallrye.metrics.interceptors.MetricResolver;
+import java.util.HashMap;
+import java.util.Map;
 import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.MetricType;
@@ -56,22 +59,16 @@ public class MetricsMetadata {
     }
 
     public static Metadata getMetadata(Object origin, String name, String unit, String description, String displayName, MetricType type, boolean reusable, String... tags) {
-        Metadata metadata = new OriginTrackedMetadata(origin, name, type);
-        if (!unit.isEmpty()) {
-            metadata.setUnit(unit);
-        }
-        if (!description.isEmpty()) {
-            metadata.setDescription(description);
-        }
-        if (!displayName.isEmpty()) {
-            metadata.setDisplayName(displayName);
-        }
-        metadata.setReusable(reusable);
+        Map<String,String> tagMap = new HashMap<>();
         if (tags != null && tags.length > 0) {
             for (String tag : tags) {
-                metadata.addTags(tag);
+                Tag t = new Tag(tag);
+                tagMap.put(t.getKey(),t.getValue());
             }
         }
+
+        Metadata metadata = new OriginTrackedMetadata(origin, name, type, unit, description, displayName, reusable,
+                                                      tagMap);
         return metadata;
     }
 

--- a/implementation/src/main/java/io/smallrye/metrics/setup/MetricsMetadata.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/MetricsMetadata.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.MetricType;
+import org.eclipse.microprofile.metrics.annotation.ConcurrentGauge;
 import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Metered;
 import org.eclipse.microprofile.metrics.annotation.Timed;
@@ -43,6 +44,12 @@ public class MetricsMetadata {
             Counted t = counted.metricAnnotation();
             Metadata metadata = getMetadata(t, counted.metricName(), t.unit(), t.description(), t.displayName(), MetricType.COUNTER, t.reusable(), t.tags());
             registry.counter(metadata);
+        }
+        MetricResolver.Of<ConcurrentGauge> concurrentGauge = resolver.concurrentGauge(bean, element);
+        if (concurrentGauge.isPresent()) {
+            ConcurrentGauge t = concurrentGauge.metricAnnotation();
+            Metadata metadata = getMetadata(t, concurrentGauge.metricName(), t.unit(), t.description(), t.displayName(), MetricType.CONCURRENT_GAUGE, t.reusable(), t.tags());
+            registry.concurrentGauge(metadata);
         }
         MetricResolver.Of<Metered> metered = resolver.metered(bean, element);
         if (metered.isPresent()) {

--- a/implementation/src/test/java/io/smallrye/metrics/MediaHandlerTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/MediaHandlerTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author hrupp
+ */
+public class MediaHandlerTest {
+
+  MetricsRequestHandler requestHandler;
+
+  @Before
+  public void setUp()  {
+
+    requestHandler = new MetricsRequestHandler();
+  }
+
+  @Test
+  public void testNotSamePrio() {
+    Optional<String> res = requestHandler.getBestMatchingMediaType(Stream.of("application/json;q=0.1",
+                                                                             "text/plain;q=0.9"));
+    assertThat(res.isPresent()).isTrue();
+    assertThat(res.get()).isEqualTo("text/plain");
+  }
+
+  @Test
+  public void testNotSamePrio2() {
+    Optional<String> res = requestHandler.getBestMatchingMediaType(Stream.of("application/json;q=0.1,text/plain;q=0.9"));
+    assertThat(res.isPresent()).isTrue();
+    assertThat(res.get()).isEqualTo("text/plain");
+  }
+
+  @Test
+  public void testSamePrio() {
+    Optional<String> res = requestHandler.getBestMatchingMediaType(Stream.of("application/json;q=0.5",
+                                                                             "text/plain;q=0.5"));
+    assertThat(res.isPresent()).isTrue();
+    assertThat(res.get()).isEqualTo("text/plain");
+  }
+
+  @Test
+  public void testSamePrio2() {
+    Optional<String> res = requestHandler.getBestMatchingMediaType(Stream.of("text/plain;q=0.5",
+                                                                             "application/json;q=0.5"
+                                                                             ));
+    assertThat(res.isPresent()).isTrue();
+    assertThat(res.get()).isEqualTo("text/plain");
+  }
+
+
+  @Test
+  public void testNoMatch() {
+    Optional<String> res = requestHandler.getBestMatchingMediaType(Stream.of("image/png",
+                                                                             "image/jpeg "));
+    assertThat(res.isPresent()).isFalse();
+  }
+
+  @Test
+  public void testBoth() {
+    Optional<String> res = requestHandler.getBestMatchingMediaType(Stream.of("application/json;q=0.1",
+                                                                             "text/plain;q=0.9"));
+    assertThat(res.isPresent()).isTrue();
+    assertThat(res.get()).isEqualTo(("text/plain"));
+  }
+
+  @Test
+  public void testBoth2() {
+    Optional<String> res = requestHandler.getBestMatchingMediaType(Stream.of("application/json;q=0.1,text/plain;q=0.9"));
+    assertThat(res.isPresent()).isTrue();
+    assertThat(res.get()).isEqualTo(("text/plain"));
+  }
+
+  @Test
+  public void testBoth3() {
+    Optional<String> res = requestHandler.getBestMatchingMediaType(Stream.of("application/json;q=0.8",
+                                                                             "text/plain;q=0.1"));
+    assertThat(res.isPresent()).isTrue();
+    assertThat(res.get()).isEqualTo("application/json");
+  }
+
+  @Test
+  public void testBoth4() {
+    Optional<String> res = requestHandler.getBestMatchingMediaType(Stream.of("application/json;q=0.8",
+                                                                             "text/plain;q=0.5",
+                                                                             "*/*;q=0.1"));
+    assertThat(res.isPresent()).isTrue();
+    assertThat(res.get()).isEqualTo("application/json");
+  }
+
+  @Test
+  public void testStarStarOnly() {
+    Optional<String> res = requestHandler.getBestMatchingMediaType(Stream.of("*/*"));
+    assertThat(res.isPresent()).isTrue();
+    assertThat(res.get()).isEqualTo("text/plain");
+  }
+
+  @Test
+  public void testStarMix() {
+    Optional<String> res = requestHandler.getBestMatchingMediaType(Stream.of("*/*;q=0.1",
+                                                                             "image/png;q=1"));
+    assertThat(res.isPresent()).isTrue();
+    assertThat(res.get()).isEqualTo("text/plain");
+  }
+
+  @Test
+  public void testStarMix2() {
+    Optional<String> res = requestHandler.getBestMatchingMediaType(Stream.of("image/png;q=1",
+                                                                             "*/*;q=0.1"));
+    assertThat(res.isPresent()).isTrue();
+    assertThat(res.get()).isEqualTo("text/plain");
+  }
+
+}

--- a/implementation/src/test/java/io/smallrye/metrics/TagsTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/TagsTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.smallrye.metrics.exporters;
+package io.smallrye.metrics;
 
 import io.smallrye.metrics.Tag;
 import org.junit.Test;

--- a/implementation/src/test/java/io/smallrye/metrics/exporters/ExportersMetricScalingTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/exporters/ExportersMetricScalingTest.java
@@ -1,0 +1,286 @@
+package io.smallrye.metrics.exporters;
+
+import io.smallrye.metrics.MetricRegistries;
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.Gauge;
+import org.eclipse.microprofile.metrics.Histogram;
+import org.eclipse.microprofile.metrics.Metadata;
+import org.eclipse.microprofile.metrics.Meter;
+import org.eclipse.microprofile.metrics.MetricFilter;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricType;
+import org.eclipse.microprofile.metrics.MetricUnits;
+import org.eclipse.microprofile.metrics.Timer;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import java.io.StringReader;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertEquals;
+
+public class ExportersMetricScalingTest {
+
+    @After
+    public void cleanup() {
+        MetricRegistries.get(MetricRegistry.Type.APPLICATION).removeMatching(MetricFilter.ALL);
+    }
+
+    /**
+     * Given a Timer with unit=MINUTES,
+     * check that the statistics from PrometheusExporter will be correctly converted to SECONDS.
+     */
+    @Test
+    public void timer_prometheus() {
+        MetricRegistry registry = MetricRegistries.get(MetricRegistry.Type.APPLICATION);
+        Metadata metadata = new Metadata("timer1", MetricType.TIMER, MetricUnits.MINUTES);
+        Timer metric = registry.timer(metadata);
+        metric.update(1, TimeUnit.HOURS);
+        metric.update(2, TimeUnit.HOURS);
+        metric.update(3, TimeUnit.HOURS);
+
+        PrometheusExporter exporter = new PrometheusExporter();
+        String exported = exporter.exportOneMetric(MetricRegistry.Type.APPLICATION, "timer1").toString();
+
+        Assert.assertThat(exported, containsString("application:timer1_seconds{quantile=\"0.5\"} 7200.0"));
+        Assert.assertThat(exported, containsString("application:timer1_mean_seconds 7200.0"));
+        Assert.assertThat(exported, containsString("application:timer1_min_seconds 3600.0"));
+        Assert.assertThat(exported, containsString("application:timer1_max_seconds 10800.0"));
+    }
+
+    /**
+     * Given a Timer with unit=MINUTES,
+     * check that the statistics from JsonExporter will be presented in MINUTES.
+     */
+    @Test
+    public void timer_json() {
+        MetricRegistry registry = MetricRegistries.get(MetricRegistry.Type.APPLICATION);
+        Metadata metadata = new Metadata("timer1", MetricType.TIMER, MetricUnits.MINUTES);
+        Timer metric = registry.timer(metadata);
+        metric.update(1, TimeUnit.HOURS);
+        metric.update(2, TimeUnit.HOURS);
+        metric.update(3, TimeUnit.HOURS);
+
+        JsonExporter exporter = new JsonExporter();
+        String exported = exporter.exportOneMetric(MetricRegistry.Type.APPLICATION, "timer1").toString();
+
+        JsonObject json = Json.createReader(new StringReader(exported)).read().asJsonObject().getJsonObject("timer1");
+        assertEquals(120.0, json.getJsonNumber("p50").doubleValue(), 0.001);
+        assertEquals(120.0, json.getJsonNumber("mean").doubleValue(), 0.001);
+        assertEquals(60.0, json.getJsonNumber("min").doubleValue(), 0.001);
+        assertEquals(180.0, json.getJsonNumber("max").doubleValue(), 0.001);
+    }
+
+    /**
+     * Given a Histogram with unit=MINUTES,
+     * check that the statistics from PrometheusExporter will be presented in SECONDS.
+     */
+    @Test
+    public void histogram_prometheus() {
+        MetricRegistry registry = MetricRegistries.get(MetricRegistry.Type.APPLICATION);
+        Metadata metadata = new Metadata("histogram1", MetricType.HISTOGRAM, MetricUnits.MINUTES);
+        Histogram metric = registry.histogram(metadata);
+        metric.update(30);
+        metric.update(40);
+        metric.update(50);
+
+        PrometheusExporter exporter = new PrometheusExporter();
+        String exported = exporter.exportOneMetric(MetricRegistry.Type.APPLICATION, "histogram1").toString();
+
+        Assert.assertThat(exported, containsString("application:histogram1_min_seconds 1800.0"));
+        Assert.assertThat(exported, containsString("application:histogram1_max_seconds 3000.0"));
+        Assert.assertThat(exported, containsString("application:histogram1_mean_seconds 2400.0"));
+        Assert.assertThat(exported, containsString("application:histogram1_seconds{quantile=\"0.5\"} 2400.0"));
+    }
+
+    /**
+     * Given a Histogram with unit=dollars (custom unit),
+     * check that the statistics from PrometheusExporter will be presented in dollars.
+     */
+    @Test
+    public void histogram_customunit_prometheus() {
+        MetricRegistry registry = MetricRegistries.get(MetricRegistry.Type.APPLICATION);
+        Metadata metadata = new Metadata("histogram1", MetricType.HISTOGRAM, "dollars");
+        Histogram metric = registry.histogram(metadata);
+        metric.update(30);
+        metric.update(40);
+        metric.update(50);
+
+        PrometheusExporter exporter = new PrometheusExporter();
+        String exported = exporter.exportOneMetric(MetricRegistry.Type.APPLICATION, "histogram1").toString();
+
+        Assert.assertThat(exported, containsString("application:histogram1_min_dollars 30.0"));
+        Assert.assertThat(exported, containsString("application:histogram1_max_dollars 50.0"));
+        Assert.assertThat(exported, containsString("application:histogram1_mean_dollars 40.0"));
+        Assert.assertThat(exported, containsString("application:histogram1_dollars{quantile=\"0.5\"} 40.0"));
+    }
+
+    /**
+     * Given a Histogram with unit=MINUTES,
+     * check that the statistics from JsonExporter will be presented in MINUTES.
+     */
+    @Test
+    public void histogram_json() {
+        MetricRegistry registry = MetricRegistries.get(MetricRegistry.Type.APPLICATION);
+        Metadata metadata = new Metadata("timer1", MetricType.TIMER, MetricUnits.MINUTES);
+        Timer metric = registry.timer(metadata);
+        metric.update(1, TimeUnit.HOURS);
+        metric.update(2, TimeUnit.HOURS);
+        metric.update(3, TimeUnit.HOURS);
+
+        JsonExporter exporter = new JsonExporter();
+        String exported = exporter.exportOneMetric(MetricRegistry.Type.APPLICATION, "timer1").toString();
+
+
+        JsonObject json = Json.createReader(new StringReader(exported)).read().asJsonObject().getJsonObject("timer1");
+        assertEquals(120.0, json.getJsonNumber("p50").doubleValue(), 0.001);
+        assertEquals(120.0, json.getJsonNumber("mean").doubleValue(), 0.001);
+        assertEquals(60.0, json.getJsonNumber("min").doubleValue(), 0.001);
+        assertEquals(180.0, json.getJsonNumber("max").doubleValue(), 0.001);
+    }
+
+    /**
+     * Given a Counter,
+     * check that the statistics from PrometheusExporter will not be scaled in any way.
+     */
+    @Test
+    public void counter_prometheus() {
+        MetricRegistry registry = MetricRegistries.get(MetricRegistry.Type.APPLICATION);
+        Metadata metadata = new Metadata("counter1", MetricType.COUNTER);
+        Counter metric = registry.counter(metadata);
+        metric.inc(30);
+        metric.inc(40);
+        metric.inc(50);
+
+        PrometheusExporter exporter = new PrometheusExporter();
+        String exported = exporter.exportOneMetric(MetricRegistry.Type.APPLICATION, "counter1").toString();
+
+        Assert.assertThat(exported, containsString("application:counter1 120.0"));
+    }
+
+    /**
+     * Given a Counter,
+     * check that the statistics from JsonExporter will not be scaled in any way.
+     */
+    @Test
+    public void counter_json() {
+        MetricRegistry registry = MetricRegistries.get(MetricRegistry.Type.APPLICATION);
+        Metadata metadata = new Metadata("counter1", MetricType.COUNTER);
+        Counter metric = registry.counter(metadata);
+        metric.inc(10);
+        metric.inc(20);
+        metric.inc(30);
+
+        JsonExporter exporter = new JsonExporter();
+        String exported = exporter.exportOneMetric(MetricRegistry.Type.APPLICATION, "counter1").toString();
+
+        JsonObject json = Json.createReader(new StringReader(exported)).read().asJsonObject();
+        assertEquals(60, json.getInt("counter1"));
+    }
+
+    /**
+     * Given a Meter,
+     * check that the statistics from PrometheusExporter will be presented as per_second.
+     */
+    @Test
+    public void meter_prometheus() throws InterruptedException {
+        MetricRegistry registry = MetricRegistries.get(MetricRegistry.Type.APPLICATION);
+        Metadata metadata = new Metadata("meter1", MetricType.METERED);
+        Meter metric = registry.meter(metadata);
+        metric.mark(10);
+        TimeUnit.SECONDS.sleep(1);
+
+        PrometheusExporter exporter = new PrometheusExporter();
+        String exported = exporter.exportOneMetric(MetricRegistry.Type.APPLICATION, "meter1").toString();
+
+        Assert.assertThat(exported, containsString("application:meter1_total 10.0"));
+        double ratePerSecond = Double.parseDouble(Arrays.stream(exported.split("\\n"))
+                .filter(line -> line.contains("application:meter1_rate_per_second"))
+                .filter(line -> !line.contains("TYPE") && !line.contains("HELP"))
+                .findFirst()
+                .get()
+                .split(" ")[1]);
+        Assert.assertTrue("Rate per second should be between 1 and 10 but is " + ratePerSecond,
+                ratePerSecond > 1 && ratePerSecond < 10);
+    }
+
+    /**
+     * Given a Meter,
+     * check that the statistics from JsonExporter will be presented as per_second.
+     */
+    @Test
+    public void meter_json() throws InterruptedException {
+        MetricRegistry registry = MetricRegistries.get(MetricRegistry.Type.APPLICATION);
+        Metadata metadata = new Metadata("meter1", MetricType.METERED);
+        Meter metric = registry.meter(metadata);
+        metric.mark(10);
+        TimeUnit.SECONDS.sleep(1);
+
+        JsonExporter exporter = new JsonExporter();
+        String exported = exporter.exportOneMetric(MetricRegistry.Type.APPLICATION, "meter1").toString();
+
+        JsonObject json = Json.createReader(new StringReader(exported)).read().asJsonObject().getJsonObject("meter1");
+        assertEquals(10, json.getInt("count"));
+        double meanRate = json.getJsonNumber("meanRate").doubleValue();
+        Assert.assertTrue("meanRate should be between 1 and 10 but is " + meanRate,
+                meanRate > 1 && meanRate < 10);
+    }
+
+    /**
+     * Given a Gauge with unit=MINUTES,
+     * check that the statistics from PrometheusExporter will be presented in SECONDS.
+     */
+    @Test
+    public void gauge_prometheus() {
+        MetricRegistry registry = MetricRegistries.get(MetricRegistry.Type.APPLICATION);
+        Metadata metadata = new Metadata("gauge1", MetricType.GAUGE, MetricUnits.MINUTES);
+        Gauge<Long> gaugeInstance = () -> 3L;
+        registry.register("gauge1", gaugeInstance, metadata);
+
+        PrometheusExporter exporter = new PrometheusExporter();
+        String exported = exporter.exportOneMetric(MetricRegistry.Type.APPLICATION, "gauge1").toString();
+
+        Assert.assertThat(exported, containsString("application:gauge1_seconds 180.0"));
+    }
+
+    /**
+     * Given a Gauge with unit=dollars (custom unit),
+     * check that the statistics from PrometheusExporter will be presented in dollars.
+     */
+    @Test
+    public void gauge_customUnit_prometheus() {
+        MetricRegistry registry = MetricRegistries.get(MetricRegistry.Type.APPLICATION);
+        Metadata metadata = new Metadata("gauge1", MetricType.GAUGE, "dollars");
+        Gauge<Long> gaugeInstance = () -> 3L;
+        registry.register("gauge1", gaugeInstance, metadata);
+
+        PrometheusExporter exporter = new PrometheusExporter();
+        String exported = exporter.exportOneMetric(MetricRegistry.Type.APPLICATION, "gauge1").toString();
+
+        Assert.assertThat(exported, containsString("application:gauge1_dollars 3.0"));
+    }
+
+    /**
+     * Given a Gauge with unit=MINUTES,
+     * check that the statistics from PrometheusExporter will be presented in MINUTES.
+     */
+    @Test
+    public void gauge_json() {
+        MetricRegistry registry = MetricRegistries.get(MetricRegistry.Type.APPLICATION);
+        Metadata metadata = new Metadata("gauge1", MetricType.GAUGE, MetricUnits.MINUTES);
+        Gauge<Long> gaugeInstance = () -> 3L;
+        registry.register("gauge1", gaugeInstance, metadata);
+
+        JsonExporter exporter = new JsonExporter();
+        String exported = exporter.exportOneMetric(MetricRegistry.Type.APPLICATION, "gauge1").toString();
+
+        JsonObject json = Json.createReader(new StringReader(exported)).read().asJsonObject();
+        assertEquals(3, json.getInt("gauge1"));
+    }
+
+}

--- a/implementation/src/test/java/io/smallrye/metrics/exporters/PrometheusExporterTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/exporters/PrometheusExporterTest.java
@@ -54,12 +54,12 @@ public class PrometheusExporterTest {
         assertNotNull(out);
 
         double valueFromPrometheus = -1;
-        for (String line : out.toString().split(LINE_SEPARATOR)) {
-            if (line.startsWith("base:jvm_uptime_seconds")) {
+        for (String line : out.toString().split(System.getProperty("line.separator"))) {
+            if (line.startsWith("base_jvm_uptime_seconds")) {
                 valueFromPrometheus /* in seconds */ = Double.valueOf(line.substring("base:jvm_uptime_seconds".length()).trim());
             }
         }
-        assertTrue(valueFromPrometheus != -1);
+        assertTrue("Value should not be -1", valueFromPrometheus != -1) ;
         assertTrue(valueFromPrometheus >= actualUptimeInSeconds);
     }
 

--- a/implementation/src/test/java/io/smallrye/metrics/exporters/PrometheusUnitScalingTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/exporters/PrometheusUnitScalingTest.java
@@ -16,6 +16,7 @@
  */
 package io.smallrye.metrics.exporters;
 
+import java.util.Optional;
 import org.eclipse.microprofile.metrics.MetricUnits;
 import org.junit.Test;
 
@@ -62,32 +63,32 @@ public class PrometheusUnitScalingTest {
     @Test
     public void testFindBaseUnit1() {
         String foo = MetricUnits.HOURS;
-        String out = PrometheusUnit.getBaseUnitAsPrometheusString(foo);
+        String out = PrometheusUnit.getBaseUnitAsPrometheusString(Optional.ofNullable(foo));
         assert out.equals(MetricUnits.SECONDS);
-        String promUnit = PrometheusUnit.getBaseUnitAsPrometheusString(out);
+        String promUnit = PrometheusUnit.getBaseUnitAsPrometheusString(Optional.ofNullable(out));
         assert promUnit.equals("seconds");
     }
 
     @Test
     public void testFindBaseUnit2() {
         String foo = MetricUnits.MILLISECONDS;
-        String out = PrometheusUnit.getBaseUnitAsPrometheusString(foo);
+        String out = PrometheusUnit.getBaseUnitAsPrometheusString(Optional.ofNullable(foo));
         assert out.equals(MetricUnits.SECONDS);
-        String promUnit = PrometheusUnit.getBaseUnitAsPrometheusString(out);
+        String promUnit = PrometheusUnit.getBaseUnitAsPrometheusString(Optional.ofNullable(out));
         assert promUnit.equals("seconds");
     }
 
     @Test
     public void testFindBaseUnit3() {
         String foo = MetricUnits.PERCENT;
-        String out = PrometheusUnit.getBaseUnitAsPrometheusString(foo);
+        String out = PrometheusUnit.getBaseUnitAsPrometheusString(Optional.ofNullable(foo));
         assert out.equals(MetricUnits.PERCENT);
     }
 
     @Test
     public void testFindBaseUnit4() {
         String foo = MetricUnits.NONE;
-        String out = PrometheusUnit.getBaseUnitAsPrometheusString(foo);
+        String out = PrometheusUnit.getBaseUnitAsPrometheusString(Optional.ofNullable(foo));
         assert out.equals(MetricUnits.NONE);
     }
 }

--- a/implementation/src/test/java/io/smallrye/metrics/exporters/SomeHistogram.java
+++ b/implementation/src/test/java/io/smallrye/metrics/exporters/SomeHistogram.java
@@ -1,0 +1,27 @@
+package io.smallrye.metrics.exporters;
+
+import org.eclipse.microprofile.metrics.Histogram;
+import org.eclipse.microprofile.metrics.Snapshot;
+
+public class SomeHistogram implements Histogram {
+
+    private Snapshot snapshot = new SomeSnapshot();
+
+    @Override
+    public void update(int value) {
+    }
+
+    @Override
+    public void update(long value) {
+    }
+
+    @Override
+    public long getCount() {
+        return 0;
+    }
+
+    @Override
+    public Snapshot getSnapshot() {
+        return snapshot ;
+    }
+}

--- a/implementation/src/test/java/io/smallrye/metrics/exporters/SomeMeter.java
+++ b/implementation/src/test/java/io/smallrye/metrics/exporters/SomeMeter.java
@@ -1,0 +1,43 @@
+package io.smallrye.metrics.exporters;
+
+import org.eclipse.microprofile.metrics.Meter;
+
+/**
+ * Provides a second (useless) Meter implementation
+ */
+public class SomeMeter implements Meter {
+    @Override
+    public void mark() {
+
+    }
+
+    @Override
+    public void mark(long l) {
+
+    }
+
+    @Override
+    public long getCount() {
+        return 0;
+    }
+
+    @Override
+    public double getFifteenMinuteRate() {
+        return 0;
+    }
+
+    @Override
+    public double getFiveMinuteRate() {
+        return 0;
+    }
+
+    @Override
+    public double getMeanRate() {
+        return 0;
+    }
+
+    @Override
+    public double getOneMinuteRate() {
+        return 0;
+    }
+}

--- a/implementation/src/test/java/io/smallrye/metrics/exporters/SomeSnapshot.java
+++ b/implementation/src/test/java/io/smallrye/metrics/exporters/SomeSnapshot.java
@@ -1,0 +1,46 @@
+package io.smallrye.metrics.exporters;
+
+import java.io.OutputStream;
+
+import org.eclipse.microprofile.metrics.Snapshot;
+
+public class SomeSnapshot extends Snapshot {
+    @Override
+    public double getValue(double quantile) {
+        return 0;
+    }
+
+    @Override
+    public long[] getValues() {
+        return new long[0];
+    }
+
+    @Override
+    public int size() {
+        return 0;
+    }
+
+    @Override
+    public long getMax() {
+        return 0;
+    }
+
+    @Override
+    public double getMean() {
+        return 0;
+    }
+
+    @Override
+    public long getMin() {
+        return 0;
+    }
+
+    @Override
+    public double getStdDev() {
+        return 0;
+    }
+
+    @Override
+    public void dump(OutputStream output) {
+    }
+}

--- a/implementation/src/test/java/io/smallrye/metrics/exporters/SomeTimer.java
+++ b/implementation/src/test/java/io/smallrye/metrics/exporters/SomeTimer.java
@@ -1,0 +1,60 @@
+package io.smallrye.metrics.exporters;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.microprofile.metrics.Snapshot;
+import org.eclipse.microprofile.metrics.Timer;
+
+public class SomeTimer implements Timer {
+
+    private Snapshot snapshot = new SomeSnapshot();
+
+    @Override
+    public void update(long duration, TimeUnit unit) {
+    }
+
+    @Override
+    public <T> T time(Callable<T> event) throws Exception {
+        return null;
+    }
+
+    @Override
+    public void time(Runnable event) {
+    }
+
+    @Override
+    public Context time() {
+        return null;
+    }
+
+    @Override
+    public long getCount() {
+        return 0;
+    }
+
+    @Override
+    public double getFifteenMinuteRate() {
+        return 0;
+    }
+
+    @Override
+    public double getFiveMinuteRate() {
+        return 0;
+    }
+
+    @Override
+    public double getMeanRate() {
+        return 0;
+    }
+
+    @Override
+    public double getOneMinuteRate() {
+        return 0;
+    }
+
+    @Override
+    public Snapshot getSnapshot() {
+        return snapshot;
+    }
+}

--- a/implementation/src/test/java/io/smallrye/metrics/setup/JmxRegistrarTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/setup/JmxRegistrarTest.java
@@ -51,12 +51,13 @@ public class JmxRegistrarTest {
         ExtendedMetadata loadedClasses = getSingleMatch("classloader\\.currentLoadedClass\\.count");
 
         assertThat(loadedClasses.getName()).isEqualTo("classloader.currentLoadedClass.count");
-        assertThat(loadedClasses.getDescription()).isEqualTo("Displays the number of classes that are currently loaded in the Java virtual machine.");
+        assertThat(loadedClasses.getDescription().get()).isEqualTo("Displays the number of classes that are currently " +
+                                                                  "loaded in the Java virtual machine.");
         assertThat(loadedClasses.getDisplayName()).isEqualTo("Current Loaded Class Count");
         assertThat(loadedClasses.getMbean()).isEqualTo("java.lang:type=ClassLoading/LoadedClassCount");
         assertThat(loadedClasses.getTags()).isEmpty();
         assertThat(loadedClasses.getType()).isEqualTo("counter");
-        assertThat(loadedClasses.getUnit()).isEqualTo("none");
+        assertThat(loadedClasses.getUnit().get()).isEqualTo("none");
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <version.arquillian>1.4.0.Final</version.arquillian>
     <version.arquillian-weld-embedded>2.0.0.Final</version.arquillian-weld-embedded>
     <version.arquillian.wildfly>2.1.0.Final</version.arquillian.wildfly>
-    <version.assertj>3.10.0</version.assertj>
+    <version.assertj>3.11.1</version.assertj>
     <version.cdi>1.2</version.cdi>
     <version.javax.json>1.1.2</version.javax.json>
     <version.glassfish.javax.json>1.1.2</version.glassfish.javax.json>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
   <properties>
     <version.microprofile-config>1.3</version.microprofile-config>
-    <version.microprofile-metrics>1.1.1</version.microprofile-metrics>
+    <version.microprofile-metrics>1.2-SNAPSHOT</version.microprofile-metrics>
 
     <version.smallrye.config>1.3.5</version.smallrye.config>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <artifactId>smallrye-metrics-parent</artifactId>
-  <version>1.1.3-SNAPSHOT</version>
+  <version>1.2-SNAPSHOT</version>
 
   <packaging>pom</packaging>
   <name>SmallRye: MicroProfile Metrics Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <version.smallrye.config>1.3.1</version.smallrye.config>
 
     <version.annotation-api>1.2</version.annotation-api>
-    <version.arquillian>1.4.0.Final</version.arquillian>
+    <version.arquillian>1.4.1.Final</version.arquillian>
     <version.arquillian-weld-embedded>2.0.0.Final</version.arquillian-weld-embedded>
     <version.arquillian.wildfly>2.1.0.Final</version.arquillian.wildfly>
     <version.assertj>3.11.1</version.assertj>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
   <properties>
     <version.microprofile-config>1.3</version.microprofile-config>
-    <version.microprofile-metrics>1.1</version.microprofile-metrics>
+    <version.microprofile-metrics>1.1.1</version.microprofile-metrics>
 
     <version.smallrye.config>1.3.1</version.smallrye.config>
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <version.annotation-api>1.2</version.annotation-api>
     <version.arquillian>1.4.1.Final</version.arquillian>
     <version.arquillian-weld-embedded>2.0.0.Final</version.arquillian-weld-embedded>
-    <version.arquillian.wildfly>2.1.0.Final</version.arquillian.wildfly>
+    <version.arquillian.wildfly>2.1.1.Final</version.arquillian.wildfly>
     <version.assertj>3.11.1</version.assertj>
     <version.cdi>1.2</version.cdi>
     <version.javax.json>1.1.4</version.javax.json>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <version.microprofile-config>1.3</version.microprofile-config>
     <version.microprofile-metrics>1.1.1</version.microprofile-metrics>
 
-    <version.smallrye.config>1.3.1</version.smallrye.config>
+    <version.smallrye.config>1.3.4</version.smallrye.config>
 
     <version.annotation-api>1.2</version.annotation-api>
     <version.arquillian>1.4.1.Final</version.arquillian>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <version.javax.json>1.1.4</version.javax.json>
     <version.glassfish.javax.json>1.1.2</version.glassfish.javax.json>
 
-    <version.jboss.servlet>1.0.0.Final</version.jboss.servlet>
+    <version.jboss.servlet>1.0.2.Final</version.jboss.servlet>
     <version.junit>4.12</version.junit>
     <version.org.jboss.logging.jboss-logging>3.3.2.Final</version.org.jboss.logging.jboss-logging>
     <version.org.jboss.weld.weld>2.4.3.Final</version.org.jboss.weld.weld>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
   <properties>
     <version.microprofile-config>1.3</version.microprofile-config>
-    <version.microprofile-metrics>1.2-SNAPSHOT</version.microprofile-metrics>
+    <version.microprofile-metrics>2.0-SNAPSHOT-1</version.microprofile-metrics>
 
     <version.smallrye.config>1.3.5</version.smallrye.config>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.smallrye</groupId>
     <artifactId>smallrye-parent</artifactId>
-    <version>1</version>
+    <version>2</version>
   </parent>
 
   <artifactId>smallrye-metrics-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <version.microprofile-config>1.3</version.microprofile-config>
     <version.microprofile-metrics>1.1.1</version.microprofile-metrics>
 
-    <version.smallrye.config>1.3.4</version.smallrye.config>
+    <version.smallrye.config>1.3.5</version.smallrye.config>
 
     <version.annotation-api>1.2</version.annotation-api>
     <version.arquillian>1.4.1.Final</version.arquillian>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 
     <version.jboss.servlet>1.0.0.Final</version.jboss.servlet>
     <version.junit>4.12</version.junit>
-    <version.org.jboss.logging.jboss-logging>3.3.1.Final</version.org.jboss.logging.jboss-logging>
+    <version.org.jboss.logging.jboss-logging>3.3.2.Final</version.org.jboss.logging.jboss-logging>
     <version.org.jboss.weld.weld>2.4.3.Final</version.org.jboss.weld.weld>
     <version.weld>2.4.7.Final</version.weld>
     <!-- Used by smallrye-metrics-rest-tck to download WildFly Servlet distribution -->

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <version.arquillian.wildfly>2.1.0.Final</version.arquillian.wildfly>
     <version.assertj>3.11.1</version.assertj>
     <version.cdi>1.2</version.cdi>
-    <version.javax.json>1.1.2</version.javax.json>
+    <version.javax.json>1.1.4</version.javax.json>
     <version.glassfish.javax.json>1.1.2</version.glassfish.javax.json>
 
     <version.jboss.servlet>1.0.0.Final</version.jboss.servlet>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 
     <version.smallrye.config>1.3.5</version.smallrye.config>
 
-    <version.annotation-api>1.2</version.annotation-api>
+    <version.annotation-api>1.3.2</version.annotation-api>
     <version.arquillian>1.4.1.Final</version.arquillian>
     <version.arquillian-weld-embedded>2.0.0.Final</version.arquillian-weld-embedded>
     <version.arquillian.wildfly>2.1.1.Final</version.arquillian.wildfly>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <version.junit>4.12</version.junit>
     <version.org.jboss.logging.jboss-logging>3.3.2.Final</version.org.jboss.logging.jboss-logging>
     <version.org.jboss.weld.weld>2.4.3.Final</version.org.jboss.weld.weld>
-    <version.weld>2.4.7.Final</version.weld>
+    <version.weld>2.4.8.Final</version.weld>
     <!-- Used by smallrye-metrics-rest-tck to download WildFly Servlet distribution -->
     <version.wildfly>13.0.0.Final</version.wildfly>
   </properties>

--- a/testsuite/extra/src/main/java/org/wildfly/swarm/microprofile/metrics/HelloService.java
+++ b/testsuite/extra/src/main/java/org/wildfly/swarm/microprofile/metrics/HelloService.java
@@ -24,7 +24,7 @@ import org.eclipse.microprofile.metrics.annotation.Timed;
 @ApplicationScoped
 public class HelloService {
 
-    @Counted(monotonic = true, name = "hello-count", absolute = true, displayName = "Hello Count", description = "Number of hello invocations")
+    @Counted(name = "hello-count", absolute = true, displayName = "Hello Count", description = "Number of hello invocations")
     public String hello() {
         return "Hello from counted method";
     }

--- a/testsuite/rest-tck/pom.xml
+++ b/testsuite/rest-tck/pom.xml
@@ -56,12 +56,20 @@
 
   </dependencies>
 
+  <properties>
+    <!-- this is for running the tests on JDK9+ where we add JAXB to the test's class path manually -->
+    <jaxb.version>2.3.1</jaxb.version>
+  </properties>
+
 
   <profiles>
     <profile>
       <id>wildfly-servlet</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <!-- use this rather than activeByDefault due to https://issues.apache.org/jira/browse/MNG-4917 -->
+          <name>!noWildflyServlet</name>
+        </property>
       </activation>
       <dependencies>
         <dependency>
@@ -75,6 +83,9 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+              <systemProperties>
+                <jboss.options>${jboss.extra.opts}</jboss.options>
+              </systemProperties>
               <environmentVariables>
                 <JBOSS_HOME>${project.build.directory}/wildfly-servlet-${version.wildfly}</JBOSS_HOME>
               </environmentVariables>
@@ -107,6 +118,27 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>jdk9plus</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <properties>
+        <jboss.extra.opts>--add-modules java.se</jboss.extra.opts>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-impl</artifactId>
+          <version>${jaxb.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+          <version>${jaxb.version}</version>
+        </dependency>
+      </dependencies>
     </profile>
   </profiles>
 


### PR DESCRIPTION
This follows changes in Metadata handling (is now immutable),
the change from Prometheus->OpenMetrics
and also improved support of Accept headers.

Note, that this requires a (not published) snapshot of MP-Metrics to succeed.

@jmartisk Please review.