### PR TITLE
Support multiple wildcards and tags for JMX

### DIFF
--- a/implementation/src/main/java/io/smallrye/metrics/setup/JmxRegistrar.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/JmxRegistrar.java
@@ -108,6 +108,15 @@ public class JmxRegistrar {
         meta.setDescription(entryProperties.get("description"));
         meta.setUnit(entryProperties.get("unit"));
         meta.setMulti("true".equalsIgnoreCase(entryProperties.get("multi")));
+        if(entryProperties.containsKey("tags")) {
+
+        	final String labelDefs[] = entryProperties.get("tags").split(";");
+        	for (final String labelDef : labelDefs) {
+        		final String label[] = labelDef.split("=", 2);
+				meta.getTags().put(label[0], label[1]);
+			}
+        	
+        }
         return meta;
     }
 

--- a/implementation/src/test/java/io/smallrye/metrics/setup/JmxRegistrarTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/setup/JmxRegistrarTest.java
@@ -16,17 +16,20 @@
  */
 package io.smallrye.metrics.setup;
 
-import io.smallrye.metrics.ExtendedMetadata;
-import org.junit.Before;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.assertj.core.util.Lists;
+import org.junit.Before;
+import org.junit.Test;
 
+import io.smallrye.metrics.ExtendedMetadata;
+import io.smallrye.metrics.JmxWorker;
 
 /**
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
@@ -76,6 +79,38 @@ public class JmxRegistrarTest {
 
     }
 
+    @Test
+    public void shouldReplaceMultipleWildcards() {
+    	assertThat(getMetadataCalled("test_key")).hasSize(1);
+    	
+    	final ExtendedMetadata extendedMetadata = getSingleMatch("test_key");
+        assertThat(extendedMetadata.getName()).isEqualTo("test_key");
+        assertThat(extendedMetadata.getDescription()).isEqualTo("Description %s1-%s2");
+        assertThat(extendedMetadata.getDisplayName()).isEqualTo("Display Name %s1-%s2");
+        assertThat(extendedMetadata.getMbean()).isEqualTo("java.nio:name=%s2,type=%s1/ObjectName");
+        assertThat(extendedMetadata.getTags()).contains(entry("type", "%s1"), entry("name", "%s2"));
+        assertThat(extendedMetadata.getType()).isEqualTo("counter");
+        assertThat(extendedMetadata.getUnit()).isEqualTo("none");
+        
+        final List<ExtendedMetadata> metadataList = Lists.list(extendedMetadata);
+        
+        JmxWorker.instance().expandMultiValueEntries(metadataList);
+        
+        assertThat(metadataList.size() == 2);
+
+        final ExtendedMetadata extendedMetadata1 = metadataList.get(0);
+        assertThat(extendedMetadata1.getDescription()).isEqualTo("Description BufferPool-mapped");
+        assertThat(extendedMetadata1.getDisplayName()).isEqualTo("Display Name BufferPool-mapped");
+        assertThat(extendedMetadata1.getMbean()).isEqualTo("java.nio:name=mapped,type=BufferPool/ObjectName");
+        assertThat(extendedMetadata1.getTags()).contains(entry("type", "BufferPool"), entry("name", "mapped"));
+        
+        final ExtendedMetadata extendedMetadata2 = metadataList.get(1);
+        assertThat(extendedMetadata2.getDescription()).isEqualTo("Description BufferPool-direct");
+        assertThat(extendedMetadata2.getDisplayName()).isEqualTo("Display Name BufferPool-direct");
+        assertThat(extendedMetadata2.getMbean()).isEqualTo("java.nio:name=direct,type=BufferPool/ObjectName");
+        assertThat(extendedMetadata2.getTags()).contains(entry("type", "BufferPool"), entry("name", "direct"));      
+    }
+    
     private ExtendedMetadata getSingleMatch(String namePattern) {
         List<ExtendedMetadata> gcList = getMetadataCalled(namePattern);
         assertThat(gcList).hasSize(1);

--- a/implementation/src/test/resources/base-metrics.properties
+++ b/implementation/src/test/resources/base-metrics.properties
@@ -25,3 +25,10 @@ gc.%s.time.unit: milliseconds
 gc.%s.time.multi: true
 gc.%s.time.description: Displays the approximate accumulated collection elapsed time in milliseconds. This attribute displays -1 if the collection elapsed time is undefined for this collector. The Java virtual machine implementation may use a high resolution timer to measure the elapsed time. This attribute may display the same value even if the collection count has been incremented if the collection elapsed time is very short.
 gc.%s.time.mbean: java.lang:type=GarbageCollector,name=%s/CollectionTime
+test_key.mbean: java.nio:name=%s2,type=%s1/ObjectName
+test_key.displayName: Display Name %s1-%s2
+test_key.type: counter
+test_key.unit: none
+test_key.multi: true
+test_key.description: Description %s1-%s2
+test_key.tags=type=%s1;name=%s2


### PR DESCRIPTION
This PR adds some more flexible JMX expressions with multiple wildcards as well as using them in tags. It fully backswards compatible with the existing "%s" syntax.

```
jboss_jdbc_active.mbean: jboss.as:subsystem=datasources,data-source=%s,statistics=pool/ActiveCount
jboss_jdbc_active.unit: connections
jboss_jdbc_active.description: Total number of connections in pool: %s
jboss_jdbc_active.multi: true
jboss_jdbc_active.type: gauge
jboss_jdbc_active.tags: data-source=%s
```
would result in prometheus metrics like this:
```
# HELP vendor:jboss_jdbc_active_connections Total number of connections in pool: ExampleDS
# TYPE vendor:jboss_jdbc_active_connections gauge
vendor:jboss_jdbc_active_connections{data-source="ExampleDS"} 0.0
```
or with multiple wildcards and syntax "%s1", "%s2", "%sN"...
```
undertow_listener_processingtime.mbean: jboss.as:subsystem=undertow,server=%s1,http-listener=%s2/processingTime
undertow_listener_processingtime.unit: nanos
undertow_listener_processingtime.description: Total processing time for this http-listener: %s1 %s2
undertow_listener_processingtime.multi: true
undertow_listener_processingtime.type: gauge
undertow_listener_processingtime.tags: server=%s1;http-listener=%s2
```
would result in prometheus metrics like this:
```
# HELP vendor:undertow_listener_processingtime_nanos Total processing time for this http-listener: default-server default
# TYPE vendor:undertow_listener_processingtime_nanos gauge
vendor:undertow_listener_processingtime_nanos{server="default-server",http-listener="default"} 0.0
```