### PR TITLE
[#53] don't append unit to counters

### DIFF
--- a/implementation/src/main/java/io/smallrye/metrics/exporters/PrometheusExporter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/exporters/PrometheusExporter.java
@@ -134,7 +134,6 @@ public class PrometheusExporter implements Exporter {
             try {
                 switch (md.getTypeRaw()) {
                     case GAUGE:
-                    case COUNTER:
                         key = getPrometheusMetricName(key);
                         String suffix = null;
                         if (!md.getUnit().equals(MetricUnits.NONE)) {
@@ -142,6 +141,12 @@ public class PrometheusExporter implements Exporter {
                         }
                         writeHelpLine(metricBuf, scope, key, md, suffix);
                         writeTypeLine(metricBuf, scope, key, md, suffix, null);
+                        createSimpleValueLine(metricBuf, scope, key, md, metric);
+                        break;
+                    case COUNTER:
+                        key = getPrometheusMetricName(key);
+                        writeHelpLine(metricBuf, scope, key, md, null);
+                        writeTypeLine(metricBuf, scope, key, md, null, null);
                         createSimpleValueLine(metricBuf, scope, key, md, metric);
                         break;
                     case METERED:


### PR DESCRIPTION
The spec says that there must be no unit appended to counters (https://github.com/eclipse/microprofile-metrics/blob/branch-1.1/spec/src/main/asciidoc/metrics_spec.adoc#325-counter-prometheus-text-format) 

This also fixes failure of relevant TCK test added through  https://github.com/eclipse/microprofile-metrics/commit/f11115affc724f6a94df8f890905e72b25bc8286 - this will be in spec 1.1.2 (not released yet)!