### PR TITLE
Eager initialization of annotation based metrics

### DIFF
--- a/implementation/src/main/java/io/smallrye/metrics/interceptors/ConcurrentGaugeInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/metrics/interceptors/ConcurrentGaugeInterceptor.java
@@ -25,10 +25,13 @@ import javax.annotation.Priority;
 import javax.enterprise.inject.Intercepted;
 import javax.enterprise.inject.spi.Bean;
 import javax.inject.Inject;
-import javax.interceptor.*;
+import javax.interceptor.AroundConstruct;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.AroundTimeout;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Member;
-import java.util.Arrays;
 
 @SuppressWarnings("unused")
 @ConcurrentGauge

--- a/implementation/src/main/java/io/smallrye/metrics/interceptors/MetricsInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/metrics/interceptors/MetricsInterceptor.java
@@ -31,7 +31,6 @@ import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 
 @SuppressWarnings("unused")
 @Interceptor
@@ -50,36 +49,20 @@ public class MetricsInterceptor {
     private MetricsInterceptor(MetricRegistry registry) {
         this.registry = registry;
         this.resolver = new MetricResolver();
-        // LOGGER.infof("MetricsInterceptor.ctor, names=%s\n", registry.getNames());
     }
 
     @AroundConstruct
     private Object metrics(InvocationContext context) throws Exception {
-        Class<?> bean = context.getConstructor().getDeclaringClass();
-        log.debugf("MetricsInterceptor, bean=%s\n", bean);
-        // Registers the bean constructor metrics
-        MetricsMetadata.registerMetrics(registry, resolver, bean, context.getConstructor());
-
-        // Registers the methods metrics over the bean type hierarchy
-        Class<?> type = bean;
-        do {
-            // TODO: discover annotations declared on implemented interfaces
-            for (Method method : type.getDeclaredMethods()) {
-                if (!method.isSynthetic() && !Modifier.isPrivate(method.getModifiers())) {
-                    MetricsMetadata.registerMetrics(registry, resolver, bean, method);
-                }
-            }
-            type = type.getSuperclass();
-        } while (!Object.class.equals(type));
+        Class<?> type = context.getConstructor().getDeclaringClass();
+        log.debugf("MetricsInterceptor, bean=%s\n", type);
 
         Object target = context.proceed();
 
         // Registers the gauges over the bean type hierarchy after the target is constructed as it is required for the gauge invocations
-        type = bean;
         do {
             // TODO: discover annotations declared on implemented interfaces
             for (Method method : type.getDeclaredMethods()) {
-                MetricResolver.Of<Gauge> gauge = resolver.gauge(bean, method);
+                MetricResolver.Of<Gauge> gauge = resolver.gauge(type, method);
                 if (gauge.isPresent()) {
                     Gauge g = gauge.metricAnnotation();
                     Metadata metadata = MetricsMetadata.getMetadata(g, gauge.metricName(), g.unit(), g.description(), g.displayName(), MetricType.GAUGE, false);

--- a/implementation/src/main/java/io/smallrye/metrics/setup/MetricCdiInjectionExtension.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/MetricCdiInjectionExtension.java
@@ -45,6 +45,7 @@ import org.jboss.logging.Logger;
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Default;
 import javax.enterprise.inject.spi.AfterDeploymentValidation;
+import javax.enterprise.inject.spi.AnnotatedConstructor;
 import javax.enterprise.inject.spi.AnnotatedMember;
 import javax.enterprise.inject.spi.AnnotatedMethod;
 import javax.enterprise.inject.spi.AnnotatedParameter;
@@ -54,6 +55,7 @@ import javax.enterprise.inject.spi.BeforeBeanDiscovery;
 import javax.enterprise.inject.spi.Extension;
 import javax.enterprise.inject.spi.InjectionPoint;
 import javax.enterprise.inject.spi.ProcessAnnotatedType;
+import javax.enterprise.inject.spi.ProcessManagedBean;
 import javax.enterprise.inject.spi.ProcessProducerField;
 import javax.enterprise.inject.spi.ProcessProducerMethod;
 import javax.enterprise.inject.spi.WithAnnotations;
@@ -79,7 +81,9 @@ public class MetricCdiInjectionExtension implements Extension {
     private static final AnnotationLiteral<Default> DEFAULT = new AnnotationLiteral<Default>() {
     };
 
-    private final Map<Bean<?>, AnnotatedMember<?>> metrics = new HashMap<>();
+    private final Map<Bean<?>, AnnotatedMember<?>> metricsFromProducers = new HashMap<>();
+
+    private final Map<Bean<?>, List<AnnotatedMember<?>>> metricsFromAnnotatedMethods = new HashMap<>();
 
     private final List<Class<?>> metricsInterfaces;
 
@@ -94,7 +98,7 @@ public class MetricCdiInjectionExtension implements Extension {
         String extensionName = MetricCdiInjectionExtension.class.getName();
 
         // It seems that fraction deployment module cannot be picked up as a CDI bean archive - see also SWARM-1725
-        for (Class clazz : new Class[] {
+        for (Class clazz : new Class[]{
                 MetricProducer.class,
                 MetricNameFactory.class,
                 MetricsInterceptor.class,
@@ -110,34 +114,60 @@ public class MetricCdiInjectionExtension implements Extension {
         }
     }
 
-    private <X> void metricsAnnotations(@Observes @WithAnnotations({ Counted.class, Gauge.class, Metered.class, Timed.class, ConcurrentGauge.class}) ProcessAnnotatedType<X> pat) {
+    // THORN-2068: MicroProfile Rest Client basic support
+    private <X> void findAnnotatedInterfaces(@Observes @WithAnnotations({Counted.class, Gauge.class, Metered.class, Timed.class, ConcurrentGauge.class}) ProcessAnnotatedType<X> pat) {
         Class<X> clazz = pat.getAnnotatedType().getJavaClass();
         Package pack = clazz.getPackage();
         if (pack != null && pack.getName().equals(MetricsInterceptor.class.getPackage().getName())) {
-            // Do not add MetricsBinding to metrics interceptor classes
             return;
         }
         if (clazz.isInterface()) {
-            // THORN-2068: MicroProfile Rest Client basic support
             // All declared metrics of an annotated interface are registered during AfterDeploymentValidation
             metricsInterfaces.add(clazz);
-        } else {
-            AnnotatedTypeDecorator newPAT = new AnnotatedTypeDecorator<>(pat.getAnnotatedType(), METRICS_BINDING);
-            log.debugf("annotations: %s", newPAT.getAnnotations());
-            log.debugf("methods: %s", newPAT.getMethods());
-            pat.setAnnotatedType(newPAT);
         }
     }
 
-    private void metricProducerField(@Observes ProcessProducerField<? extends Metric, ?> ppf) {
-        log.infof("Metrics producer field discovered: %s", ppf.getAnnotatedProducerField());
-        metrics.put(ppf.getBean(), ppf.getAnnotatedProducerField());
+    // for classes with at least one gauge, apply @MetricsBinding which serves for gauge registration
+    private <X> void applyMetricsBinding(@Observes @WithAnnotations({Gauge.class}) ProcessAnnotatedType<X> pat) {
+        Class<X> clazz = pat.getAnnotatedType().getJavaClass();
+        Package pack = clazz.getPackage();
+        if (pack == null || !pack.getName().equals(MetricsInterceptor.class.getPackage().getName())) {
+            if (!clazz.isInterface()) {
+                AnnotatedTypeDecorator newPAT = new AnnotatedTypeDecorator<>(pat.getAnnotatedType(), METRICS_BINDING);
+                log.debugf("annotations: %s", newPAT.getAnnotations());
+                log.debugf("methods: %s", newPAT.getMethods());
+                pat.setAnnotatedType(newPAT);
+            }
+        }
+
     }
 
-    private void metricProducerMethod(@Observes ProcessProducerMethod<? extends Metric, ?> ppm) {
+    private <X> void findAnnotatedMethods(@Observes ProcessManagedBean<X> bean) {
+        if (bean.getBean().getBeanClass().getPackage().equals(MetricsInterceptor.class.getPackage())) {
+            return;
+        }
+        ArrayList<AnnotatedMember<?>> list = new ArrayList<>();
+        for (AnnotatedMethod<? super X> aMethod : bean.getAnnotatedBeanClass().getMethods()) {
+            Method method = aMethod.getJavaMember();
+            if (!method.isSynthetic() && !Modifier.isPrivate(method.getModifiers())) {
+                list.add(aMethod);
+            }
+        }
+        list.addAll(bean.getAnnotatedBeanClass().getConstructors());
+        if (!list.isEmpty()) {
+            metricsFromAnnotatedMethods.put(bean.getBean(), list);
+        }
+    }
+
+    private void findMetricProducerFields(@Observes ProcessProducerField<? extends Metric, ?> ppf) {
+        log.infof("Metrics producer field discovered: %s", ppf.getAnnotatedProducerField());
+        metricsFromProducers.put(ppf.getBean(), ppf.getAnnotatedProducerField());
+    }
+
+    private void findMetricProducerMethods(@Observes ProcessProducerMethod<? extends Metric, ?> ppm) {
         if (!ppm.getBean().getBeanClass().equals(MetricProducer.class)) {
             log.infof("Metrics producer method discovered: %s", ppm.getAnnotatedProducerMethod());
-            metrics.put(ppm.getBean(), ppm.getAnnotatedProducerMethod());
+            metricsFromProducers.put(ppm.getBean(), ppm.getAnnotatedProducerMethod());
         }
     }
 
@@ -146,18 +176,22 @@ public class MetricCdiInjectionExtension implements Extension {
         // Produce and register custom metrics
         MetricRegistry registry = getReference(manager, MetricRegistry.class);
         MetricName name = getReference(manager, MetricName.class);
-        for (Map.Entry<Bean<?>, AnnotatedMember<?>> bean : metrics.entrySet()) {
+        for (Map.Entry<Bean<?>, AnnotatedMember<?>> bean : metricsFromProducers.entrySet()) {
             if (// skip non @Default beans
-            !bean.getKey().getQualifiers().contains(DEFAULT)
-                    // skip producer methods with injection point metadata
-                    || hasInjectionPointMetadata(bean.getValue())) {
+                    !bean.getKey().getQualifiers().contains(DEFAULT)
+                            // skip producer methods with injection point metadata
+                            || hasInjectionPointMetadata(bean.getValue())) {
                 continue;
             }
 
             String metricName = name.of(bean.getValue());
             org.eclipse.microprofile.metrics.annotation.Metric metricAnnotation = bean.getValue().getAnnotation(org.eclipse.microprofile.metrics.annotation.Metric.class);
-            if(metricAnnotation != null) {
+            if (metricAnnotation != null) {
                 Object reference = getReference(manager, bean.getValue().getBaseType(), bean.getKey());
+                if (reference == null) {
+                    adv.addDeploymentProblem(new IllegalStateException("null was returned from " + bean.getValue()));
+                    return;
+                }
                 Class<?> clazz = reference.getClass();
                 MetricType type = MetricType.from(clazz.getInterfaces().length == 0 ? clazz.getSuperclass().getInterfaces()[0] : clazz.getInterfaces()[0]);
                 Metadata metadata = MetricsMetadata.getMetadata(metricAnnotation,
@@ -174,6 +208,18 @@ public class MetricCdiInjectionExtension implements Extension {
             }
         }
 
+        for (Map.Entry<Bean<?>, List<AnnotatedMember<?>>> entry : metricsFromAnnotatedMethods.entrySet()) {
+            Bean<?> bean = entry.getKey();
+            for (AnnotatedMember<?> method : entry.getValue()) {
+                MetricsMetadata.registerMetrics(registry,
+                        new MetricResolver(),
+                        bean.getBeanClass(),
+                        method instanceof AnnotatedMethod<?> ?
+                                ((AnnotatedMethod<?>) method).getJavaMember() :
+                                ((AnnotatedConstructor<?>) method).getJavaMember());
+            }
+        }
+
         // THORN-2068: MicroProfile Rest Client basic support
         if (!metricsInterfaces.isEmpty()) {
             MetricResolver resolver = new MetricResolver();
@@ -185,10 +231,12 @@ public class MetricCdiInjectionExtension implements Extension {
                 }
             }
         }
+
         metricsInterfaces.clear();
 
-        // Let's clear the collected metric producers
-        metrics.clear();
+        // Let's clear the collected metrics
+        metricsFromProducers.clear();
+        metricsFromAnnotatedMethods.clear();
     }
 
     private static boolean hasInjectionPointMetadata(AnnotatedMember<?> member) {

--- a/implementation/src/test/java/io/smallrye/metrics/exporters/OpenMetricsExporterTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/exporters/OpenMetricsExporterTest.java
@@ -51,7 +51,10 @@ import static io.smallrye.metrics.exporters.OpenMetricsExporter.getOpenMetricsMe
 import static java.util.regex.Pattern.quote;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class OpenMetricsExporterTest {
 

--- a/implementation/src/test/java/io/smallrye/metrics/registration/MetadataMismatchTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/registration/MetadataMismatchTest.java
@@ -27,7 +27,10 @@ import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 public class MetadataMismatchTest {
 

--- a/implementation/src/test/java/io/smallrye/metrics/registration/MetricTypeMismatchTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/registration/MetricTypeMismatchTest.java
@@ -26,7 +26,9 @@ import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 public class MetricTypeMismatchTest {
 

--- a/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/dependentscoped/DependentScopedBeanWithGauge.java
+++ b/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/dependentscoped/DependentScopedBeanWithGauge.java
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-package org.wildfly.swarm.microprofile.metrics.normalscoped;
+package org.wildfly.swarm.microprofile.metrics.dependentscoped;
 
 import org.eclipse.microprofile.metrics.MetricUnits;
-import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Gauge;
-import org.eclipse.microprofile.metrics.annotation.Metered;
 
-public class NormalScopedBeanWithGauge {
+public class DependentScopedBeanWithGauge {
 
     @Gauge(name = "gauge", absolute = true, unit = MetricUnits.DAYS)
     public Long gaugedMethod() {

--- a/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/dependentscoped/DependentScopedBeanWithMetrics.java
+++ b/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/dependentscoped/DependentScopedBeanWithMetrics.java
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-package org.wildfly.swarm.microprofile.metrics.normalscoped;
+package org.wildfly.swarm.microprofile.metrics.dependentscoped;
 
 import org.eclipse.microprofile.metrics.annotation.ConcurrentGauge;
 import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Metered;
 import org.eclipse.microprofile.metrics.annotation.Timed;
 
-public class NormalScopedBeanWithMetrics {
+public class DependentScopedBeanWithMetrics {
 
     @Counted(name = "counter", absolute = true)
     public void countedMethod() {

--- a/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/dependentscoped/GaugeInDependentScopedBeanTest.java
+++ b/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/dependentscoped/GaugeInDependentScopedBeanTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.wildfly.swarm.microprofile.metrics.normalscoped;
+package org.wildfly.swarm.microprofile.metrics.dependentscoped;
 
 import io.smallrye.metrics.MetricRegistries;
 import org.eclipse.microprofile.metrics.MetricFilter;
@@ -39,13 +39,13 @@ import javax.inject.Inject;
  * create ambiguity.
  */
 @RunWith(Arquillian.class)
-public class GaugeInNormalScopedBeanTest {
+public class GaugeInDependentScopedBeanTest {
 
     @Deployment
     public static WebArchive deployment() {
         return ShrinkWrap.create(WebArchive.class)
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
-                .addClass(NormalScopedBeanWithGauge.class);
+                .addClass(DependentScopedBeanWithGauge.class);
     }
 
     @After
@@ -54,13 +54,13 @@ public class GaugeInNormalScopedBeanTest {
     }
 
     @Inject
-    private Instance<NormalScopedBeanWithGauge> beanInstance;
+    private Instance<DependentScopedBeanWithGauge> beanInstance;
 
     @Test
     public void gauge() {
         try {
-            NormalScopedBeanWithGauge instance1 = beanInstance.get();
-            NormalScopedBeanWithGauge instance2 = beanInstance.get();
+            DependentScopedBeanWithGauge instance1 = beanInstance.get();
+            DependentScopedBeanWithGauge instance2 = beanInstance.get();
             Assert.fail("Shouldn't be able to create multiple instances of a bean that contains a gauge");
         } catch(Exception e) {
 

--- a/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/dependentscoped/MetricsInDependentScopedBeanTest.java
+++ b/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/dependentscoped/MetricsInDependentScopedBeanTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.wildfly.swarm.microprofile.metrics.normalscoped;
+package org.wildfly.swarm.microprofile.metrics.dependentscoped;
 
 import io.smallrye.metrics.MetricRegistries;
 import org.eclipse.microprofile.metrics.MetricFilter;
@@ -25,7 +25,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -41,30 +41,30 @@ import static org.junit.Assert.assertEquals;
  * This does not work for gauges because a gauge must always be bound to just one object.
  */
 @RunWith(Arquillian.class)
-public class MetricsInNormalScopedBeanTest {
+public class MetricsInDependentScopedBeanTest {
 
     @Deployment
     public static WebArchive deployment() {
         return ShrinkWrap.create(WebArchive.class)
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
-                .addClass(NormalScopedBeanWithMetrics.class);
+                .addClass(DependentScopedBeanWithMetrics.class);
     }
 
-    @After
-    public void cleanupApplicationMetrics() {
+    @AfterClass
+    public static void cleanupApplicationMetrics() {
         MetricRegistries.get(MetricRegistry.Type.APPLICATION).removeMatching(MetricFilter.ALL);
     }
 
     @Inject
-    private Instance<NormalScopedBeanWithMetrics> beanInstance;
+    private Instance<DependentScopedBeanWithMetrics> beanInstance;
 
     @Inject
     private MetricRegistry registry;
 
     @Test
     public void counter() {
-        NormalScopedBeanWithMetrics instance1 = beanInstance.get();
-        NormalScopedBeanWithMetrics instance2 = beanInstance.get();
+        DependentScopedBeanWithMetrics instance1 = beanInstance.get();
+        DependentScopedBeanWithMetrics instance2 = beanInstance.get();
 
         instance1.countedMethod();
         instance2.countedMethod();
@@ -74,8 +74,8 @@ public class MetricsInNormalScopedBeanTest {
 
     @Test
     public void meter() {
-        NormalScopedBeanWithMetrics instance1 = beanInstance.get();
-        NormalScopedBeanWithMetrics instance2 = beanInstance.get();
+        DependentScopedBeanWithMetrics instance1 = beanInstance.get();
+        DependentScopedBeanWithMetrics instance2 = beanInstance.get();
 
         instance1.meteredMethod();
         instance2.meteredMethod();
@@ -85,8 +85,8 @@ public class MetricsInNormalScopedBeanTest {
 
     @Test
     public void timer() {
-        NormalScopedBeanWithMetrics instance1 = beanInstance.get();
-        NormalScopedBeanWithMetrics instance2 = beanInstance.get();
+        DependentScopedBeanWithMetrics instance1 = beanInstance.get();
+        DependentScopedBeanWithMetrics instance2 = beanInstance.get();
 
         instance1.timedMethod();
         instance2.timedMethod();
@@ -96,8 +96,8 @@ public class MetricsInNormalScopedBeanTest {
 
     @Test
     public void concurrentGauge() {
-        NormalScopedBeanWithMetrics instance1 = beanInstance.get();
-        NormalScopedBeanWithMetrics instance2 = beanInstance.get();
+        DependentScopedBeanWithMetrics instance1 = beanInstance.get();
+        DependentScopedBeanWithMetrics instance2 = beanInstance.get();
 
         instance1.cGaugedMethod();
         instance2.cGaugedMethod();

--- a/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_ConcurrentGauge_Method_Test.java
+++ b/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_ConcurrentGauge_Method_Test.java
@@ -15,51 +15,48 @@
  *   limitations under the License.
  */
 
-package org.wildfly.swarm.microprofile.metrics.reusability;
+package org.wildfly.swarm.microprofile.metrics.initialization;
 
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.annotation.ConcurrentGauge;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import javax.inject.Inject;
 
-/**
- * Test that if the same metric annotation is repeated and the metric is not marked as reusable, the metric will be rejected.
- */
-@RunWith(Arquillian.class)
-public class NonReusableMetricTest {
+import static org.junit.Assert.assertTrue;
 
-    @Inject
-    private NonReusableMetricBean bean;
+@RunWith(Arquillian.class)
+public class Initialization_ConcurrentGauge_Method_Test {
 
     @Deployment
     public static WebArchive deployment() {
         return ShrinkWrap.create(WebArchive.class)
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
-                .addClass(NonReusableMetricBean.class);
+                .addClasses(BeanWithConcurrentGauge_Method.class);
     }
 
-    // FIXME this test depends on the behavior that annotation-based metrics from ApplicationScoped beans are not registered eagerly
-    // but instead they are registered during instantiation of the bean. So if we change that behavior, this test will break.
-    // The problem is that if you force the failure eagerly, which causes the whole deployment to fail, I'm not sure how to
-    // write a reliable test that can catch a deployment exception
+    @Inject
+    MetricRegistry registry;
+
     @Test
-    @Ignore
     public void test() {
-        try {
-            // trigger instantiation of the bean
-            // this should trigger an error
-            bean.countedMethodOne();
-            Assert.fail("Metric registration should not go through");
-        } catch(Exception e) {
-            e.printStackTrace();
+        assertTrue(registry.getConcurrentGauges().containsKey(new MetricID("cgauged_method")));
+    }
+
+    public static class BeanWithConcurrentGauge_Method {
+
+        @ConcurrentGauge(name = "cgauged_method", absolute = true)
+        public void cGaugedMethod() {
+
         }
+
     }
 
 }

--- a/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_Counter_ClassLevel_Test.java
+++ b/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_Counter_ClassLevel_Test.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.wildfly.swarm.microprofile.metrics.initialization;
+
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.Tag;
+import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Arquillian.class)
+public class Initialization_Counter_ClassLevel_Test {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addClasses(BeanWithCounter_ClassLevel.class);
+    }
+
+    @Inject
+    MetricRegistry registry;
+
+    @Test
+    public void test() {
+        // metric should be created for the constructor
+        assertTrue(registry.getCounters().containsKey(new MetricID("customName.BeanWithCounter_ClassLevel", new Tag("t1", "v1"))));
+
+        // metrics should be created for public methods
+        assertTrue(registry.getCounters().containsKey(new MetricID("customName.publicMethod", new Tag("t1", "v1"))));
+        assertTrue(registry.getCounters().containsKey(new MetricID("customName.publicMethod2", new Tag("t1", "v1"))));
+
+        // but not for private methods
+        assertFalse(registry.getCounters().keySet().stream().anyMatch(metricID -> metricID.getName().toLowerCase().contains("private")));
+    }
+
+    @Counted(name = "customName", tags = "t1=v1", absolute = true)
+    private static class BeanWithCounter_ClassLevel {
+
+        public BeanWithCounter_ClassLevel() {
+
+        }
+
+        public void publicMethod() {
+
+        }
+
+        public void publicMethod2() {
+
+        }
+
+        private void privateMethod() {
+
+        }
+
+    }
+
+}

--- a/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_Counter_Constructor_Test.java
+++ b/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_Counter_Constructor_Test.java
@@ -1,0 +1,52 @@
+package org.wildfly.swarm.microprofile.metrics.initialization;
+
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(Arquillian.class)
+public class Initialization_Counter_Constructor_Test {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addClasses(BeanWithCounter_Constructor.class);
+    }
+
+    @Inject
+    MetricRegistry registry;
+
+    @Test
+    public void test() {
+        Counter metricFromConstructor = registry.getCounters()
+                .get(new MetricID("org.wildfly.swarm.microprofile.metrics.initialization.Initialization_Counter_Constructor_Test" +
+                        "$BeanWithCounter_Constructor.BeanWithCounter_Constructor"));
+        assertNotNull(metricFromConstructor);
+        assertEquals(1, registry.getCounters().size());
+    }
+
+    private static class BeanWithCounter_Constructor {
+
+        @Counted
+        public BeanWithCounter_Constructor() {
+
+        }
+
+    }
+
+
+}

--- a/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_Counter_Method_Reusable_Test.java
+++ b/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_Counter_Method_Reusable_Test.java
@@ -1,0 +1,66 @@
+package org.wildfly.swarm.microprofile.metrics.initialization;
+
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.annotation.security.PermitAll;
+import javax.inject.Inject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Arquillian.class)
+public class Initialization_Counter_Method_Reusable_Test {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addClasses(BeanWithCounter_Method_Reusable.class);
+    }
+
+    @Inject
+    private MetricRegistry registry;
+
+    @Inject
+    private BeanWithCounter_Method_Reusable bean;
+
+    @Test
+    public void test() {
+        assertTrue(registry.getCounters().containsKey(new MetricID("counter_method")));
+        assertTrue(registry.getCounters((metricID, metric) -> metricID.getName().contains("irrelevant")).isEmpty());
+        bean.counterMethod();
+        assertEquals(1, registry.getCounters().get(new MetricID("counter_method")).getCount());
+        bean.counterMethod2();
+        assertEquals(2, registry.getCounters().get(new MetricID("counter_method")).getCount());
+        assertEquals(1, registry.getCounters().size());
+    }
+
+    public static class BeanWithCounter_Method_Reusable {
+
+        @Counted(name = "counter_method", absolute = true, reusable = true)
+        public void counterMethod() {
+
+        }
+
+        @Counted(name = "counter_method", absolute = true, reusable = true)
+        public void counterMethod2() {
+
+        }
+
+        @PermitAll
+        public void irrelevantAnnotatedMethod() {
+
+        }
+
+    }
+
+}

--- a/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_Counter_Method_Test.java
+++ b/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_Counter_Method_Test.java
@@ -1,0 +1,60 @@
+package org.wildfly.swarm.microprofile.metrics.initialization;
+
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.annotation.security.PermitAll;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Arquillian.class)
+public class Initialization_Counter_Method_Test {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addClasses(BeanWithCounter_Method.class);
+    }
+
+    @Inject
+    MetricRegistry registry;
+
+    @Inject
+    BeanWithCounter_Method bean;
+
+    @Test
+    public void test() {
+        assertTrue(registry.getCounters().containsKey(new MetricID("counter_method")));
+        assertTrue(registry.getCounters((metricID, metric) -> metricID.getName().contains("irrelevant")).isEmpty());
+        bean.counterMethod();
+        Assert.assertEquals(1, registry.getCounters().get(new MetricID("counter_method")).getCount());
+    }
+
+    @ApplicationScoped
+    public static class BeanWithCounter_Method {
+
+        @Counted(name = "counter_method", absolute = true)
+        public void counterMethod() {
+
+        }
+
+        @PermitAll
+        public void irrelevantAnnotatedMethod() {
+
+        }
+
+    }
+
+}

--- a/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_Gauge_Method_Test.java
+++ b/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_Gauge_Method_Test.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.wildfly.swarm.microprofile.metrics.initialization;
+
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricUnits;
+import org.eclipse.microprofile.metrics.annotation.Gauge;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Arquillian.class)
+public class Initialization_Gauge_Method_Test {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addClasses(BeanWithGauge_ApplicationScoped.class);
+    }
+
+    @Inject
+    MetricRegistry registry;
+
+    @Inject
+    BeanWithGauge_ApplicationScoped applicationScopedBean;
+
+
+    /**
+     * With a gauge in an application-scoped bean, the metric will be registered once the bean is instantiated.
+     */
+    @Test
+    public void testApplicationScoped() {
+        applicationScopedBean.gauge(); // access the application-scoped bean so that an instance gets created
+        assertTrue(registry.getGauges().containsKey(new MetricID("gaugeApp")));
+        Assert.assertEquals(2L, registry.getGauges().get(new MetricID("gaugeApp")).getValue());
+        Assert.assertEquals(3L, registry.getGauges().get(new MetricID("gaugeApp")).getValue());
+    }
+
+    @ApplicationScoped
+    public static class BeanWithGauge_ApplicationScoped {
+
+        Long i = 0L;
+
+        @Gauge(name = "gaugeApp", absolute = true, unit = MetricUnits.NONE)
+        public Long gauge() {
+            return ++i;
+        }
+
+    }
+
+}

--- a/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_Injection_Test.java
+++ b/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_Injection_Test.java
@@ -15,51 +15,60 @@
  *   limitations under the License.
  */
 
-package org.wildfly.swarm.microprofile.metrics.reusability;
+package org.wildfly.swarm.microprofile.metrics.initialization;
 
+import org.eclipse.microprofile.metrics.Histogram;
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.annotation.Metric;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import javax.inject.Inject;
 
-/**
- * Test that if the same metric annotation is repeated and the metric is not marked as reusable, the metric will be rejected.
- */
-@RunWith(Arquillian.class)
-public class NonReusableMetricTest {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
-    @Inject
-    private NonReusableMetricBean bean;
+@RunWith(Arquillian.class)
+public class Initialization_Injection_Test {
 
     @Deployment
     public static WebArchive deployment() {
         return ShrinkWrap.create(WebArchive.class)
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
-                .addClass(NonReusableMetricBean.class);
+                .addClasses(BeanWithMetricInjection.class);
     }
 
-    // FIXME this test depends on the behavior that annotation-based metrics from ApplicationScoped beans are not registered eagerly
-    // but instead they are registered during instantiation of the bean. So if we change that behavior, this test will break.
-    // The problem is that if you force the failure eagerly, which causes the whole deployment to fail, I'm not sure how to
-    // write a reliable test that can catch a deployment exception
+    @Inject
+    MetricRegistry registry;
+
+    @Inject
+    BeanWithMetricInjection bean;
+
     @Test
-    @Ignore
     public void test() {
-        try {
-            // trigger instantiation of the bean
-            // this should trigger an error
-            bean.countedMethodOne();
-            Assert.fail("Metric registration should not go through");
-        } catch(Exception e) {
-            e.printStackTrace();
+        MetricID metricID = new MetricID("org.wildfly.swarm.microprofile.metrics.initialization.Initialization_Injection_Test$BeanWithMetricInjection.histogram");
+        // check that the injected histogram is registered eagerly
+        assertTrue(registry.getHistograms().containsKey(metricID));
+        bean.addDataToHistogram();
+        assertEquals(10, registry.getHistograms().get(metricID).getSnapshot().getMax());
+    }
+
+    public static class BeanWithMetricInjection {
+
+        @Inject
+        @Metric
+        Histogram histogram;
+
+        public void addDataToHistogram() {
+            histogram.update(10);
         }
+
     }
 
 }

--- a/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_Meter_Method_Test.java
+++ b/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_Meter_Method_Test.java
@@ -1,0 +1,52 @@
+package org.wildfly.swarm.microprofile.metrics.initialization;
+
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.annotation.Metered;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Arquillian.class)
+public class Initialization_Meter_Method_Test {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addClasses(BeanWithMeter_Method.class);
+    }
+
+    @Inject
+    MetricRegistry registry;
+
+    @Inject
+    BeanWithMeter_Method bean;
+
+    @Test
+    public void test() {
+        assertTrue(registry.getMeters().containsKey(new MetricID("meter_method")));
+        bean.meterMethod();
+        assertEquals(1, registry.getMeters().get(new MetricID("meter_method")).getCount());
+    }
+
+    public static class BeanWithMeter_Method {
+
+        @Metered(name = "meter_method", absolute = true)
+        public void meterMethod() {
+
+        }
+
+    }
+
+
+}

--- a/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_ProducerField_Test.java
+++ b/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_ProducerField_Test.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.wildfly.swarm.microprofile.metrics.initialization;
+
+import io.smallrye.metrics.app.CounterImpl;
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.Histogram;
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.annotation.Metric;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Arquillian.class)
+public class Initialization_ProducerField_Test {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addClasses(BeanWithMetricProducerField.class);
+    }
+
+    @Inject
+    MetricRegistry registry;
+
+    @Inject
+    BeanWithMetricProducerField bean;
+
+    @Test
+    public void test() {
+        MetricID metricID = new MetricID("counter1");
+        // check eager initialization here
+        assertTrue(registry.getCounters().containsKey(metricID));
+        assertEquals(0, registry.getCounters().get(metricID).getCount());
+        bean.addDataToCounter();
+        Counter counter = registry.getCounters().get(metricID);
+        assertEquals(1, counter.getCount());
+    }
+
+    public static class BeanWithMetricProducerField {
+
+        @Inject
+        MetricRegistry registry;
+
+        @Produces
+        @ApplicationScoped
+        @Metric(name = "counter1", absolute = true)
+        Counter c1 = new CounterImpl();
+
+        public void addDataToCounter() {
+            registry.getCounters().get(new MetricID("counter1")).inc();
+        }
+
+    }
+
+}

--- a/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_ProducerMethod_Test.java
+++ b/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_ProducerMethod_Test.java
@@ -15,51 +15,64 @@
  *   limitations under the License.
  */
 
-package org.wildfly.swarm.microprofile.metrics.reusability;
+package org.wildfly.swarm.microprofile.metrics.initialization;
 
+import io.smallrye.metrics.app.CounterImpl;
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.annotation.Metric;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 
-/**
- * Test that if the same metric annotation is repeated and the metric is not marked as reusable, the metric will be rejected.
- */
-@RunWith(Arquillian.class)
-public class NonReusableMetricTest {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
-    @Inject
-    private NonReusableMetricBean bean;
+@RunWith(Arquillian.class)
+public class Initialization_ProducerMethod_Test {
 
     @Deployment
     public static WebArchive deployment() {
         return ShrinkWrap.create(WebArchive.class)
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
-                .addClass(NonReusableMetricBean.class);
+                .addClasses(BeanWithMetricProducerMethod.class);
     }
 
-    // FIXME this test depends on the behavior that annotation-based metrics from ApplicationScoped beans are not registered eagerly
-    // but instead they are registered during instantiation of the bean. So if we change that behavior, this test will break.
-    // The problem is that if you force the failure eagerly, which causes the whole deployment to fail, I'm not sure how to
-    // write a reliable test that can catch a deployment exception
+    @Inject
+    MetricRegistry registry;
+
+    @Inject
+    BeanWithMetricProducerMethod bean;
+
     @Test
-    @Ignore
     public void test() {
-        try {
-            // trigger instantiation of the bean
-            // this should trigger an error
-            bean.countedMethodOne();
-            Assert.fail("Metric registration should not go through");
-        } catch(Exception e) {
-            e.printStackTrace();
+        MetricID metricID = new MetricID("c1");
+        assertTrue(registry.getCounters().containsKey(metricID));
+        assertEquals(111, registry.getCounters().get(metricID).getCount());
+    }
+
+    public static class BeanWithMetricProducerMethod {
+
+        // a Counter that always returns 111
+        @Produces
+        @Metric(name = "c1", absolute = true)
+        public Counter producer() {
+            return new CounterImpl() {
+                @Override
+                public long getCount() {
+                    return 111;
+                }
+            };
         }
+
     }
 
 }

--- a/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_Timer_Method_Test.java
+++ b/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_Timer_Method_Test.java
@@ -15,51 +15,54 @@
  *   limitations under the License.
  */
 
-package org.wildfly.swarm.microprofile.metrics.reusability;
+package org.wildfly.swarm.microprofile.metrics.initialization;
 
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.annotation.Timed;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import javax.inject.Inject;
 
-/**
- * Test that if the same metric annotation is repeated and the metric is not marked as reusable, the metric will be rejected.
- */
-@RunWith(Arquillian.class)
-public class NonReusableMetricTest {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
-    @Inject
-    private NonReusableMetricBean bean;
+@RunWith(Arquillian.class)
+public class Initialization_Timer_Method_Test {
 
     @Deployment
     public static WebArchive deployment() {
         return ShrinkWrap.create(WebArchive.class)
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
-                .addClass(NonReusableMetricBean.class);
+                .addClasses(BeanWithTimer_Method.class);
     }
 
-    // FIXME this test depends on the behavior that annotation-based metrics from ApplicationScoped beans are not registered eagerly
-    // but instead they are registered during instantiation of the bean. So if we change that behavior, this test will break.
-    // The problem is that if you force the failure eagerly, which causes the whole deployment to fail, I'm not sure how to
-    // write a reliable test that can catch a deployment exception
+    @Inject
+    MetricRegistry registry;
+
+    @Inject
+    BeanWithTimer_Method bean;
+
     @Test
-    @Ignore
     public void test() {
-        try {
-            // trigger instantiation of the bean
-            // this should trigger an error
-            bean.countedMethodOne();
-            Assert.fail("Metric registration should not go through");
-        } catch(Exception e) {
-            e.printStackTrace();
+        assertTrue(registry.getTimers().containsKey(new MetricID("timed_method")));
+        bean.timedMethod();
+        assertEquals(1, registry.getTimers().get(new MetricID("timed_method")).getCount());
+    }
+
+    public static class BeanWithTimer_Method {
+
+        @Timed(name = "timed_method", absolute = true)
+        public void timedMethod() {
+
         }
+
     }
 
 }


### PR DESCRIPTION
Initialize annotation based metrics during init of the CDI container
Fixes https://github.com/quarkusio/quarkus/issues/1435 for Quarkus and https://github.com/smallrye/smallrye-metrics/issues/80 for SR-Metrics