### PR TITLE
Making the metadata map concurrent as well

### DIFF
--- a/implementation/src/main/java/io/smallrye/metrics/MetricsRegistryImpl.java
+++ b/implementation/src/main/java/io/smallrye/metrics/MetricsRegistryImpl.java
@@ -57,7 +57,7 @@ public class MetricsRegistryImpl extends MetricRegistry {
     private static Logger log = Logger.getLogger(MetricsRegistryImpl.class);
     private static String NONE = "NONE";
 
-    private Map<String, Metadata> metadataMap = new HashMap<>();
+    private Map<String, Metadata> metadataMap = new ConcurrentHashMap<>();
 
     private Map<MetricID, Metric> metricMap = new ConcurrentHashMap<>();
 


### PR DESCRIPTION
One of the Thorntail tests fails with NPE [at this point](https://github.com/smallrye/smallrye-metrics/blob/1.1.3/implementation/src/main/java/io/smallrye/metrics/MetricsRegistryImpl.java#L342). 
Using the concurrent map will detect earlier when a null value is inserted and it also makes sense to have both the metrics and the metadata maps concurrent 