### PR TITLE
Preparations for metric eager init

### DIFF
--- a/implementation/src/main/java/io/smallrye/metrics/elementdesc/AnnotationInfo.java
+++ b/implementation/src/main/java/io/smallrye/metrics/elementdesc/AnnotationInfo.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.smallrye.metrics.elementdesc;
+
+public interface AnnotationInfo {
+
+    String name();
+
+    boolean absolute();
+
+    String[] tags();
+
+    String unit();
+
+    String description();
+
+    String displayName();
+
+    boolean reusable();
+
+    boolean monotonic();
+
+    String annotationName();
+
+}

--- a/implementation/src/main/java/io/smallrye/metrics/elementdesc/BeanInfo.java
+++ b/implementation/src/main/java/io/smallrye/metrics/elementdesc/BeanInfo.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.smallrye.metrics.elementdesc;
+
+import java.lang.annotation.Annotation;
+
+public interface BeanInfo {
+
+    String getSimpleName();
+
+    String getPackageName();
+
+    <T extends Annotation> AnnotationInfo getAnnotation(Class<T> metric);
+
+    <T extends Annotation> boolean isAnnotationPresent(Class<T> metric);
+
+    /**
+     * Returns BeanInfo of its superclass or null if there is no superclass.
+     */
+    BeanInfo getSuperclass();
+
+}

--- a/implementation/src/main/java/io/smallrye/metrics/elementdesc/MemberInfo.java
+++ b/implementation/src/main/java/io/smallrye/metrics/elementdesc/MemberInfo.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.smallrye.metrics.elementdesc;
+
+import java.lang.annotation.Annotation;
+
+public interface MemberInfo {
+
+    MemberType getMemberType();
+
+    String getDeclaringClassName();
+
+    String getDeclaringClassSimpleName();
+
+    String getName();
+
+    <T extends Annotation> boolean isAnnotationPresent(Class<T> metric);
+
+    <T extends Annotation> AnnotationInfo getAnnotation(Class<T> metric);
+
+}

--- a/implementation/src/main/java/io/smallrye/metrics/elementdesc/MemberType.java
+++ b/implementation/src/main/java/io/smallrye/metrics/elementdesc/MemberType.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.smallrye.metrics.elementdesc;
+
+public enum MemberType {
+
+    CONSTRUCTOR,
+    METHOD,
+    FIELD
+
+}

--- a/implementation/src/main/java/io/smallrye/metrics/elementdesc/RawAnnotationInfo.java
+++ b/implementation/src/main/java/io/smallrye/metrics/elementdesc/RawAnnotationInfo.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.smallrye.metrics.elementdesc;
+
+public class RawAnnotationInfo implements AnnotationInfo {
+
+    private String name;
+
+    private boolean absolute;
+
+    private String[] tags;
+
+    private String unit;
+
+    private String description;
+
+    private String displayName;
+
+    private boolean reusable;
+
+    private boolean monotonic;
+
+    private String annotationName;
+
+    public RawAnnotationInfo() {
+
+    }
+
+    public RawAnnotationInfo(String name, boolean absolute, String[] tags, String unit,
+                             String description, String displayName, boolean reusable, boolean monotonic, String annotationName) {
+        this.name = name;
+        this.absolute = absolute;
+        this.tags = tags;
+        this.unit = unit;
+        this.description = description;
+        this.displayName = displayName;
+        this.reusable = reusable;
+        this.monotonic = monotonic;
+        this.annotationName = annotationName;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public boolean isAbsolute() {
+        return absolute;
+    }
+
+    public void setAbsolute(boolean absolute) {
+        this.absolute = absolute;
+    }
+
+    public String[] getTags() {
+        return tags;
+    }
+
+    public void setTags(String[] tags) {
+        this.tags = tags;
+    }
+
+    public String getUnit() {
+        return unit;
+    }
+
+    public void setUnit(String unit) {
+        this.unit = unit;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public boolean isReusable() {
+        return reusable;
+    }
+
+    public void setReusable(boolean reusable) {
+        this.reusable = reusable;
+    }
+
+    public boolean isMonotonic() {
+        return monotonic;
+    }
+
+    public void setMonotonic(boolean monotonic) {
+        this.monotonic = monotonic;
+    }
+
+    public String getAnnotationName() {
+        return annotationName;
+    }
+
+    public void setAnnotationName(String annotationName) {
+        this.annotationName = annotationName;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public boolean absolute() {
+        return absolute;
+    }
+
+    @Override
+    public String[] tags() {
+        return tags;
+    }
+
+    @Override
+    public String unit() {
+        return unit;
+    }
+
+    @Override
+    public String description() {
+        return description;
+    }
+
+    @Override
+    public String displayName() {
+        return displayName;
+    }
+
+    @Override
+    public boolean reusable() {
+        return reusable;
+    }
+
+    @Override
+    public boolean monotonic() {
+        return monotonic;
+    }
+
+    @Override
+    public String annotationName() {
+        return annotationName;
+    }
+
+
+}

--- a/implementation/src/main/java/io/smallrye/metrics/elementdesc/RawBeanInfo.java
+++ b/implementation/src/main/java/io/smallrye/metrics/elementdesc/RawBeanInfo.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.smallrye.metrics.elementdesc;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class RawBeanInfo implements BeanInfo {
+
+    private String simpleName;
+
+    private String packageName;
+
+    private List<AnnotationInfo> annotationInfos = new ArrayList<>();
+    private AnnotationInfo[] infosArray;
+
+    private BeanInfo superClassInfo;
+
+    public RawBeanInfo() {
+
+    }
+
+    public RawBeanInfo(String simpleName, String packageName, Collection<AnnotationInfo> annotationInfos, BeanInfo superClassInfo) {
+        this.simpleName = simpleName;
+        this.packageName = packageName;
+        this.annotationInfos.addAll(annotationInfos);
+        this.superClassInfo = superClassInfo;
+        this.infosArray = annotationInfos.toArray(new AnnotationInfo[]{});
+    }
+
+    public void setSimpleName(String simpleName) {
+        this.simpleName = simpleName;
+    }
+
+    public void setPackageName(String packageName) {
+        this.packageName = packageName;
+    }
+
+    public List<AnnotationInfo> getAnnotationInfos() {
+        return annotationInfos;
+    }
+
+    public void setAnnotationInfos(List<AnnotationInfo> annotationInfos) {
+        this.annotationInfos = annotationInfos;
+    }
+
+    public AnnotationInfo[] getInfosArray() {
+        return infosArray;
+    }
+
+    public void setInfosArray(AnnotationInfo[] infosArray) {
+        this.infosArray = infosArray;
+    }
+
+    public BeanInfo getSuperClassInfo() {
+        return superClassInfo;
+    }
+
+    public void setSuperClassInfo(BeanInfo superClassInfo) {
+        this.superClassInfo = superClassInfo;
+    }
+
+    @Override
+    public String getSimpleName() {
+        return simpleName;
+    }
+
+    @Override
+    public String getPackageName() {
+        return packageName;
+    }
+
+    @Override
+    public <T extends Annotation> AnnotationInfo getAnnotation(Class<T> metric) {
+        return annotationInfos.stream().filter(annotation -> annotation.name().equals(metric.getName())).findFirst().orElse(null);
+    }
+
+    @Override
+    public <T extends Annotation> boolean isAnnotationPresent(Class<T> metric) {
+        return annotationInfos.stream().anyMatch(annotation -> annotation.name().equals(metric.getName()));
+    }
+
+    @Override
+    public BeanInfo getSuperclass() {
+        return superClassInfo;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if(!(obj instanceof BeanInfo)) {
+            return false;
+        } else {
+            return this.getSimpleName().equals(((BeanInfo)obj).getSimpleName());
+        }
+    }
+}

--- a/implementation/src/main/java/io/smallrye/metrics/elementdesc/RawMemberInfo.java
+++ b/implementation/src/main/java/io/smallrye/metrics/elementdesc/RawMemberInfo.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.smallrye.metrics.elementdesc;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class RawMemberInfo implements MemberInfo {
+
+    private MemberType memberType;
+
+    private String declaringClassName;
+
+    private String declaringClassSimpleName;
+
+    private String name;
+
+    private List<AnnotationInfo> annotationInfos = new ArrayList<>();
+
+    public RawMemberInfo() {
+
+    }
+
+    public RawMemberInfo(MemberType memberType, String declaringClassName, String declaringClassSimpleName, String name, Collection<AnnotationInfo> annotationInfos) {
+        this.memberType = memberType;
+        this.declaringClassName = declaringClassName;
+        this.declaringClassSimpleName = declaringClassSimpleName;
+        this.name = name;
+        this.annotationInfos.addAll(annotationInfos);
+    }
+
+    public void setMemberType(MemberType memberType) {
+        this.memberType = memberType;
+    }
+
+    public void setDeclaringClassName(String declaringClassName) {
+        this.declaringClassName = declaringClassName;
+    }
+
+    public void setDeclaringClassSimpleName(String declaringClassSimpleName) {
+        this.declaringClassSimpleName = declaringClassSimpleName;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setAnnotationInfos(List<AnnotationInfo> annotationInfos) {
+        this.annotationInfos = annotationInfos;
+    }
+
+    public List<AnnotationInfo> getAnnotationInfos() {
+        return annotationInfos;
+    }
+
+
+    @Override
+    public MemberType getMemberType() {
+        return memberType;
+    }
+
+    @Override
+    public String getDeclaringClassName() {
+        return declaringClassName;
+    }
+
+    @Override
+    public String getDeclaringClassSimpleName() {
+        return declaringClassSimpleName;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public <T extends Annotation> AnnotationInfo getAnnotation(Class<T> metricClass) {
+        return annotationInfos.stream().filter(annotation -> annotation.annotationName().equals(metricClass.getName())).findFirst().orElse(null);
+    }
+
+    @Override
+    public <T extends Annotation> boolean isAnnotationPresent(Class<T> metricClass) {
+        return annotationInfos.stream().anyMatch(annotation -> annotation.annotationName().equals(metricClass.getName()));
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if(!(obj instanceof MemberInfo)) {
+            return false;
+        }
+        MemberInfo other = (MemberInfo)obj;
+        return other.getDeclaringClassName().equals(this.getDeclaringClassName()) &&
+                other.getName().equals(this.getName());
+    }
+}

--- a/implementation/src/main/java/io/smallrye/metrics/elementdesc/adapter/AnnotationInfoAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/elementdesc/adapter/AnnotationInfoAdapter.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.smallrye.metrics.elementdesc.adapter;
+
+import io.smallrye.metrics.elementdesc.AnnotationInfo;
+
+public interface AnnotationInfoAdapter<I> {
+
+    AnnotationInfo convert(I input);
+}

--- a/implementation/src/main/java/io/smallrye/metrics/elementdesc/adapter/BeanInfoAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/elementdesc/adapter/BeanInfoAdapter.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.smallrye.metrics.elementdesc.adapter;
+
+import io.smallrye.metrics.elementdesc.BeanInfo;
+
+public interface BeanInfoAdapter<T> {
+
+    BeanInfo convert(T input);
+
+}

--- a/implementation/src/main/java/io/smallrye/metrics/elementdesc/adapter/MemberInfoAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/elementdesc/adapter/MemberInfoAdapter.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.smallrye.metrics.elementdesc.adapter;
+
+import io.smallrye.metrics.elementdesc.MemberInfo;
+
+public interface MemberInfoAdapter<T> {
+
+    MemberInfo convert(T input);
+
+}

--- a/implementation/src/main/java/io/smallrye/metrics/elementdesc/adapter/cdi/CDIAnnotationInfo.java
+++ b/implementation/src/main/java/io/smallrye/metrics/elementdesc/adapter/cdi/CDIAnnotationInfo.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.smallrye.metrics.elementdesc.adapter.cdi;
+
+import io.smallrye.metrics.elementdesc.AnnotationInfo;
+import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.eclipse.microprofile.metrics.annotation.Gauge;
+import org.eclipse.microprofile.metrics.annotation.Metered;
+import org.eclipse.microprofile.metrics.annotation.Timed;
+
+import java.lang.annotation.Annotation;
+
+public class CDIAnnotationInfo implements AnnotationInfo {
+
+    private final Annotation annotation;
+
+    CDIAnnotationInfo(Annotation annotation) {
+        this.annotation = annotation;
+    }
+
+    @Override
+    public String name() {
+        if (annotation instanceof Counted) {
+            return ((Counted) annotation).name();
+        } else if (annotation instanceof Gauge) {
+            return ((Gauge) annotation).name();
+        } else if (annotation instanceof Metered) {
+            return ((Metered) annotation).name();
+        } else if (annotation instanceof Timed) {
+            return ((Timed) annotation).name();
+        } else {
+            throw new IllegalArgumentException("Unknown metric annotation type " + annotation.annotationType());
+        }
+    }
+
+    @Override
+    public boolean absolute() {
+        if (annotation instanceof Counted) {
+            return ((Counted) annotation).absolute();
+        } else if (annotation instanceof Gauge) {
+            return ((Gauge) annotation).absolute();
+        } else if (annotation instanceof Metered) {
+            return ((Metered) annotation).absolute();
+        } else if (annotation instanceof Timed) {
+            return ((Timed) annotation).absolute();
+        } else {
+            throw new IllegalArgumentException("Unknown metric annotation type " + annotation.annotationType());
+        }
+    }
+
+    @Override
+    public String[] tags() {
+        if (annotation instanceof Counted) {
+            return ((Counted) annotation).tags();
+        } else if (annotation instanceof Gauge) {
+            return ((Gauge) annotation).tags();
+        } else if (annotation instanceof Metered) {
+            return ((Metered) annotation).tags();
+        } else if (annotation instanceof Timed) {
+            return ((Timed) annotation).tags();
+        } else {
+            throw new IllegalArgumentException("Unknown metric annotation type " + annotation.annotationType());
+        }
+    }
+
+    @Override
+    public String unit() {
+        if (annotation instanceof Counted) {
+            return ((Counted) annotation).unit();
+        } else if (annotation instanceof Gauge) {
+            return ((Gauge) annotation).unit();
+        } else if (annotation instanceof Metered) {
+            return ((Metered) annotation).unit();
+        } else if (annotation instanceof Timed) {
+            return ((Timed) annotation).unit();
+        } else {
+            throw new IllegalArgumentException("Unknown metric annotation type " + annotation.annotationType());
+        }
+    }
+
+    @Override
+    public String description() {
+        if (annotation instanceof Counted) {
+            return ((Counted) annotation).description();
+        } else if (annotation instanceof Gauge) {
+            return ((Gauge) annotation).description();
+        } else if (annotation instanceof Metered) {
+            return ((Metered) annotation).description();
+        } else if (annotation instanceof Timed) {
+            return ((Timed) annotation).description();
+        } else {
+            throw new IllegalArgumentException("Unknown metric annotation type " + annotation.annotationType());
+        }
+    }
+
+    @Override
+    public String displayName() {
+        if (annotation instanceof Counted) {
+            return ((Counted) annotation).displayName();
+        } else if (annotation instanceof Gauge) {
+            return ((Gauge) annotation).displayName();
+        } else if (annotation instanceof Metered) {
+            return ((Metered) annotation).displayName();
+        } else if (annotation instanceof Timed) {
+            return ((Timed) annotation).displayName();
+        } else {
+            throw new IllegalArgumentException("Unknown metric annotation type " + annotation.annotationType());
+        }
+    }
+
+    @Override
+    public boolean reusable() {
+        if (annotation instanceof Counted) {
+            return ((Counted) annotation).reusable();
+        } else if (annotation instanceof Gauge) {
+            return false;
+        } else if (annotation instanceof Metered) {
+            return ((Metered) annotation).reusable();
+        } else if (annotation instanceof Timed) {
+            return ((Timed) annotation).reusable();
+        } else {
+            throw new IllegalArgumentException("Unknown metric annotation type " + annotation.annotationType());
+        }
+    }
+
+    @Override
+    public boolean monotonic() {
+        if (annotation instanceof Counted) {
+            return ((Counted) annotation).monotonic();
+        } else {
+            throw new IllegalArgumentException("Only counters have 'monotonic' attribute");
+        }
+    }
+
+    @Override
+    public String annotationName() {
+        return annotation.annotationType().getName();
+    }
+
+    @Override
+    public String toString() {
+        return annotation.toString();
+    }
+
+}

--- a/implementation/src/main/java/io/smallrye/metrics/elementdesc/adapter/cdi/CDIAnnotationInfoAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/elementdesc/adapter/cdi/CDIAnnotationInfoAdapter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.smallrye.metrics.elementdesc.adapter.cdi;
+
+import io.smallrye.metrics.elementdesc.AnnotationInfo;
+import io.smallrye.metrics.elementdesc.adapter.AnnotationInfoAdapter;
+
+import java.lang.annotation.Annotation;
+
+public class CDIAnnotationInfoAdapter implements AnnotationInfoAdapter<Annotation> {
+
+    @Override
+    public AnnotationInfo convert(Annotation annotation) {
+        return new CDIAnnotationInfo(annotation);
+    }
+
+}

--- a/implementation/src/main/java/io/smallrye/metrics/elementdesc/adapter/cdi/CDIBeanInfo.java
+++ b/implementation/src/main/java/io/smallrye/metrics/elementdesc/adapter/cdi/CDIBeanInfo.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.smallrye.metrics.elementdesc.adapter.cdi;
+
+import io.smallrye.metrics.elementdesc.AnnotationInfo;
+import io.smallrye.metrics.elementdesc.BeanInfo;
+
+import java.lang.annotation.Annotation;
+
+public class CDIBeanInfo implements BeanInfo {
+
+    private final Class<?> input;
+
+    CDIBeanInfo(Class<?> input) {
+        this.input = input;
+    }
+
+    @Override
+    public String getSimpleName() {
+        return input.getSimpleName();
+    }
+
+    @Override
+    public String getPackageName() {
+        return input.getPackage().getName();
+    }
+
+    @Override
+    public <T extends Annotation> AnnotationInfo getAnnotation(Class<T> metric) {
+        T annotation = input.getAnnotation(metric);
+        if(annotation != null) {
+            return new CDIAnnotationInfoAdapter().convert(annotation);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public <T extends Annotation> boolean isAnnotationPresent(Class<T> metric) {
+        return input.isAnnotationPresent(metric);
+    }
+
+    @Override
+    public BeanInfo getSuperclass() {
+        Class<?> superclass = input.getSuperclass();
+        if (superclass != null) {
+            return new CDIBeanInfo(superclass);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return input.toString();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if(!(obj instanceof CDIBeanInfo)) {
+            return false;
+        } else {
+            return this.getSimpleName().equals(((CDIBeanInfo)obj).getSimpleName());
+        }
+    }
+}

--- a/implementation/src/main/java/io/smallrye/metrics/elementdesc/adapter/cdi/CDIBeanInfoAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/elementdesc/adapter/cdi/CDIBeanInfoAdapter.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.smallrye.metrics.elementdesc.adapter.cdi;
+
+import io.smallrye.metrics.elementdesc.BeanInfo;
+import io.smallrye.metrics.elementdesc.adapter.BeanInfoAdapter;
+
+public class CDIBeanInfoAdapter implements BeanInfoAdapter<Class<?>> {
+
+    @Override
+    public BeanInfo convert(Class<?> input) {
+        return new CDIBeanInfo(input);
+    }
+
+}

--- a/implementation/src/main/java/io/smallrye/metrics/elementdesc/adapter/cdi/CDIMemberInfo.java
+++ b/implementation/src/main/java/io/smallrye/metrics/elementdesc/adapter/cdi/CDIMemberInfo.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.smallrye.metrics.elementdesc.adapter.cdi;
+
+import io.smallrye.metrics.elementdesc.AnnotationInfo;
+import io.smallrye.metrics.elementdesc.MemberInfo;
+import io.smallrye.metrics.elementdesc.MemberType;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+
+public class CDIMemberInfo implements MemberInfo {
+
+    private final Object input;
+
+    <T extends Member & AnnotatedElement> CDIMemberInfo(T input) {
+        this.input = input;
+    }
+
+    @Override
+    public MemberType getMemberType() {
+        if(input instanceof Constructor) {
+            return MemberType.CONSTRUCTOR;
+        } else if(input instanceof Method) {
+            return MemberType.METHOD;
+        } else if(input instanceof Field) {
+            return MemberType.FIELD;
+        } else {
+            throw new Error("Unknown/unsupported member type");
+        }
+    }
+
+    @Override
+    public String getDeclaringClassName() {
+        return ((Member)input).getDeclaringClass().getName();
+    }
+
+    @Override
+    public String getDeclaringClassSimpleName() {
+        return ((Member)input).getDeclaringClass().getSimpleName();
+    }
+
+    @Override
+    public String getName() {
+        return ((Member)input).getName();
+    }
+
+    @Override
+    public <X extends Annotation> boolean isAnnotationPresent(Class<X> metric) {
+        return ((AnnotatedElement)input).isAnnotationPresent(metric);
+    }
+
+    @Override
+    public <X extends Annotation> AnnotationInfo getAnnotation(Class<X> metric) {
+        X annotation = ((AnnotatedElement)input).getAnnotation(metric);
+        if(annotation != null) {
+            return new CDIAnnotationInfoAdapter().convert(annotation);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if(!(obj instanceof MemberInfo)) {
+            return false;
+        }
+        MemberInfo other = (MemberInfo)obj;
+        return other.getDeclaringClassName().equals(this.getDeclaringClassName()) &&
+                other.getName().equals(this.getName());
+    }
+
+    @Override
+    public String toString() {
+        return input.toString();
+    }
+}

--- a/implementation/src/main/java/io/smallrye/metrics/elementdesc/adapter/cdi/CDIMemberInfoAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/elementdesc/adapter/cdi/CDIMemberInfoAdapter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.smallrye.metrics.elementdesc.adapter.cdi;
+
+import io.smallrye.metrics.elementdesc.MemberInfo;
+import io.smallrye.metrics.elementdesc.adapter.MemberInfoAdapter;
+
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Member;
+
+public class CDIMemberInfoAdapter<T extends Member & AnnotatedElement> implements MemberInfoAdapter<T> {
+
+    @Override
+    public MemberInfo convert(T input) {
+        return new CDIMemberInfo(input);
+    }
+
+}

--- a/implementation/src/main/java/io/smallrye/metrics/interceptors/CountedInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/metrics/interceptors/CountedInterceptor.java
@@ -15,6 +15,9 @@
  */
 package io.smallrye.metrics.interceptors;
 
+import io.smallrye.metrics.elementdesc.adapter.BeanInfoAdapter;
+import io.smallrye.metrics.elementdesc.adapter.cdi.CDIBeanInfoAdapter;
+import io.smallrye.metrics.elementdesc.adapter.cdi.CDIMemberInfoAdapter;
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.annotation.Counted;
@@ -69,7 +72,12 @@ public class CountedInterceptor {
     }
 
     private <E extends Member & AnnotatedElement> Object countedCallable(InvocationContext context, E element) throws Exception {
-        MetricResolver.Of<Counted> counted = resolver.counted(bean != null ? bean.getBeanClass() : element.getDeclaringClass(), element);
+        BeanInfoAdapter<Class<?>> beanInfoAdapter = new CDIBeanInfoAdapter();
+        CDIMemberInfoAdapter memberInfoAdapter = new CDIMemberInfoAdapter();
+        MetricResolver.Of<Counted> counted = resolver.counted(
+                bean != null ? beanInfoAdapter.convert(bean.getBeanClass()) : beanInfoAdapter.convert(element.getDeclaringClass()),
+                memberInfoAdapter.convert(element)
+        );
         String name = counted.metricName();
         Counter counter = (Counter) registry.getCounters().get(name);
         if (counter == null) {

--- a/implementation/src/main/java/io/smallrye/metrics/interceptors/MeteredInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/metrics/interceptors/MeteredInterceptor.java
@@ -18,6 +18,9 @@
 package io.smallrye.metrics.interceptors;
 
 
+import io.smallrye.metrics.elementdesc.adapter.BeanInfoAdapter;
+import io.smallrye.metrics.elementdesc.adapter.cdi.CDIBeanInfoAdapter;
+import io.smallrye.metrics.elementdesc.adapter.cdi.CDIMemberInfoAdapter;
 import org.eclipse.microprofile.metrics.Meter;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.annotation.Metered;
@@ -69,7 +72,12 @@ public class MeteredInterceptor {
     }
 
     private <E extends Member & AnnotatedElement> Object meteredCallable(InvocationContext context, E element) throws Exception {
-        String name = resolver.metered(bean != null ? bean.getBeanClass() : element.getDeclaringClass(), element).metricName();
+        BeanInfoAdapter<Class<?>> beanInfoAdapter = new CDIBeanInfoAdapter();
+        CDIMemberInfoAdapter memberInfoAdapter = new CDIMemberInfoAdapter();
+        MetricResolver.Of<Metered> meterResolver = resolver.metered(
+                bean != null ? beanInfoAdapter.convert(bean.getBeanClass()) : beanInfoAdapter.convert(element.getDeclaringClass()),
+                memberInfoAdapter.convert(element));
+        String name = meterResolver.metricName();
         Meter meter = (Meter) registry.getMetrics().get(name);
         if (meter == null) {
             throw new IllegalStateException("No meter with name [" + name + "] found in registry [" + registry + "]");

--- a/implementation/src/main/java/io/smallrye/metrics/interceptors/MetricsInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/metrics/interceptors/MetricsInterceptor.java
@@ -30,7 +30,6 @@ import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 
 @SuppressWarnings("unused")
 @Interceptor
@@ -49,36 +48,20 @@ public class MetricsInterceptor {
     private MetricsInterceptor(MetricRegistry registry) {
         this.registry = registry;
         this.resolver = new MetricResolver();
-        // LOGGER.infof("MetricsInterceptor.ctor, names=%s\n", registry.getNames());
     }
 
     @AroundConstruct
     private Object metrics(InvocationContext context) throws Exception {
-        Class<?> bean = context.getConstructor().getDeclaringClass();
-        log.debugf("MetricsInterceptor, bean=%s\n", bean);
-        // Registers the bean constructor metrics
-        MetricsMetadata.registerMetrics(registry, resolver, bean, context.getConstructor());
-
-        // Registers the methods metrics over the bean type hierarchy
-        Class<?> type = bean;
-        do {
-            // TODO: discover annotations declared on implemented interfaces
-            for (Method method : type.getDeclaredMethods()) {
-                if (!method.isSynthetic() && !Modifier.isPrivate(method.getModifiers())) {
-                    MetricsMetadata.registerMetrics(registry, resolver, bean, method);
-                }
-            }
-            type = type.getSuperclass();
-        } while (!Object.class.equals(type));
+        Class<?> type = context.getConstructor().getDeclaringClass();
+        log.debugf("MetricsInterceptor, bean=%s\n", type);
 
         Object target = context.proceed();
 
         // Registers the gauges over the bean type hierarchy after the target is constructed as it is required for the gauge invocations
-        type = bean;
         do {
             // TODO: discover annotations declared on implemented interfaces
             for (Method method : type.getDeclaredMethods()) {
-                MetricResolver.Of<Gauge> gauge = resolver.gauge(bean, method);
+                MetricResolver.Of<Gauge> gauge = resolver.gauge(type, method);
                 if (gauge.isPresent()) {
                     Gauge g = gauge.metricAnnotation();
                     Metadata metadata = MetricsMetadata.getMetadata(g, gauge.metricName(), g.unit(), g.description(), g.displayName(), MetricType.GAUGE, false, g.tags());

--- a/implementation/src/main/java/io/smallrye/metrics/setup/MetricCdiInjectionExtension.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/MetricCdiInjectionExtension.java
@@ -20,6 +20,9 @@ package io.smallrye.metrics.setup;
 import io.smallrye.metrics.MetricProducer;
 import io.smallrye.metrics.MetricRegistries;
 import io.smallrye.metrics.MetricsRequestHandler;
+import io.smallrye.metrics.elementdesc.adapter.BeanInfoAdapter;
+import io.smallrye.metrics.elementdesc.adapter.cdi.CDIBeanInfoAdapter;
+import io.smallrye.metrics.elementdesc.adapter.cdi.CDIMemberInfoAdapter;
 import io.smallrye.metrics.interceptors.CountedInterceptor;
 import io.smallrye.metrics.interceptors.MeteredInterceptor;
 import io.smallrye.metrics.interceptors.MetricName;
@@ -41,7 +44,6 @@ import org.jboss.logging.Logger;
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Default;
 import javax.enterprise.inject.spi.AfterDeploymentValidation;
-import javax.enterprise.inject.spi.AnnotatedConstructor;
 import javax.enterprise.inject.spi.AnnotatedMember;
 import javax.enterprise.inject.spi.AnnotatedMethod;
 import javax.enterprise.inject.spi.AnnotatedParameter;
@@ -170,6 +172,9 @@ public class MetricCdiInjectionExtension implements Extension {
         // Produce and register custom metrics
         MetricRegistry registry = getReference(manager, MetricRegistry.class);
         MetricName name = getReference(manager, MetricName.class);
+        BeanInfoAdapter<Class<?>> beanInfoAdapter = new CDIBeanInfoAdapter();
+        CDIMemberInfoAdapter memberInfoAdapter = new CDIMemberInfoAdapter();
+
         for (Map.Entry<Bean<?>, AnnotatedMember<?>> bean : metricsFromProducers.entrySet()) {
             if (// skip non @Default beans
                     !bean.getKey().getQualifiers().contains(DEFAULT)
@@ -203,10 +208,8 @@ public class MetricCdiInjectionExtension implements Extension {
             for (AnnotatedMember<?> method : entry.getValue()) {
                 MetricsMetadata.registerMetrics(registry,
                         new MetricResolver(),
-                        bean.getBeanClass(),
-                        method instanceof AnnotatedMethod<?> ?
-                                ((AnnotatedMethod<?>) method).getJavaMember() :
-                                ((AnnotatedConstructor<?>) method).getJavaMember());
+                        beanInfoAdapter.convert(bean.getBeanClass()),
+                        memberInfoAdapter.convert(method.getJavaMember()));
             }
         }
 
@@ -216,7 +219,7 @@ public class MetricCdiInjectionExtension implements Extension {
             for (Class<?> metricsInterface : metricsInterfaces) {
                 for (Method method : metricsInterface.getDeclaredMethods()) {
                     if (!method.isDefault() && !Modifier.isStatic(method.getModifiers())) {
-                        MetricsMetadata.registerMetrics(registry, resolver, metricsInterface, method);
+                        MetricsMetadata.registerMetrics(registry, resolver, beanInfoAdapter.convert(metricsInterface), memberInfoAdapter.convert(method));
                     }
                 }
             }

--- a/implementation/src/main/java/io/smallrye/metrics/setup/MetricsMetadata.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/MetricsMetadata.java
@@ -18,6 +18,9 @@
 package io.smallrye.metrics.setup;
 
 import io.smallrye.metrics.OriginTrackedMetadata;
+import io.smallrye.metrics.elementdesc.AnnotationInfo;
+import io.smallrye.metrics.elementdesc.BeanInfo;
+import io.smallrye.metrics.elementdesc.MemberInfo;
 import io.smallrye.metrics.interceptors.MetricResolver;
 import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.MetricRegistry;
@@ -26,31 +29,28 @@ import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Metered;
 import org.eclipse.microprofile.metrics.annotation.Timed;
 
-import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.Member;
-
 public class MetricsMetadata {
 
     private MetricsMetadata() {
     }
 
-    public static <E extends Member & AnnotatedElement> void registerMetrics(MetricRegistry registry, MetricResolver resolver, Class<?> bean, E element) {
+    public static void registerMetrics(MetricRegistry registry, MetricResolver resolver, BeanInfo bean, MemberInfo element) {
         MetricResolver.Of<Counted> counted = resolver.counted(bean, element);
         if (counted.isPresent()) {
-            Counted t = counted.metricAnnotation();
-            Metadata metadata = getMetadata(t, counted.metricName(), t.unit(), t.description(), t.displayName(), MetricType.COUNTER, t.reusable(), t.tags());
+            AnnotationInfo t = counted.metricAnnotation();
+            Metadata metadata = getMetadata(element, counted.metricName(), t.unit(), t.description(), t.displayName(), MetricType.COUNTER, t.reusable(), t.tags());
             registry.counter(metadata);
         }
         MetricResolver.Of<Metered> metered = resolver.metered(bean, element);
         if (metered.isPresent()) {
-            Metered t = metered.metricAnnotation();
-            Metadata metadata = getMetadata(t, metered.metricName(), t.unit(), t.description(), t.displayName(), MetricType.METERED, t.reusable(), t.tags());
+            AnnotationInfo t = metered.metricAnnotation();
+            Metadata metadata = getMetadata(element, metered.metricName(), t.unit(), t.description(), t.displayName(), MetricType.METERED, t.reusable(), t.tags());
             registry.meter(metadata);
         }
         MetricResolver.Of<Timed> timed = resolver.timed(bean, element);
         if (timed.isPresent()) {
-            Timed t = timed.metricAnnotation();
-            Metadata metadata = getMetadata(t, timed.metricName(), t.unit(), t.description(), t.displayName(), MetricType.TIMER, t.reusable(), t.tags());
+            AnnotationInfo t = timed.metricAnnotation();
+            Metadata metadata = getMetadata(element, timed.metricName(), t.unit(), t.description(), t.displayName(), MetricType.TIMER, t.reusable(), t.tags());
             registry.timer(metadata);
         }
     }

--- a/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/dependentscoped/DependentScopedBeanWithGauge.java
+++ b/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/dependentscoped/DependentScopedBeanWithGauge.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.swarm.microprofile.metrics.dependentscoped;
+
+import org.eclipse.microprofile.metrics.MetricUnits;
+import org.eclipse.microprofile.metrics.annotation.Gauge;
+
+public class DependentScopedBeanWithGauge {
+
+    @Gauge(name = "gauge", absolute = true, unit = MetricUnits.DAYS)
+    public Long gaugedMethod() {
+        return 42L;
+    }
+
+}

--- a/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/dependentscoped/DependentScopedBeanWithMetrics.java
+++ b/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/dependentscoped/DependentScopedBeanWithMetrics.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.swarm.microprofile.metrics.dependentscoped;
+
+import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.eclipse.microprofile.metrics.annotation.Metered;
+import org.eclipse.microprofile.metrics.annotation.Timed;
+
+public class DependentScopedBeanWithMetrics {
+
+    @Counted(name = "counter", absolute = true, monotonic = true)
+    public void countedMethod() {
+
+    }
+
+    @Metered(name = "meter", absolute = true)
+    public void meteredMethod() {
+
+    }
+
+    @Timed(name = "timer", absolute = true)
+    public void timedMethod() {
+
+    }
+
+}

--- a/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/dependentscoped/GaugeInDependentScopedBeanTest.java
+++ b/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/dependentscoped/GaugeInDependentScopedBeanTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.swarm.microprofile.metrics.dependentscoped;
+
+import io.smallrye.metrics.MetricRegistries;
+import org.eclipse.microprofile.metrics.MetricFilter;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+/**
+ * Gauges can only be used with AnnotationScoped beans. If we place a gauge on a bean that creates multiple
+ * instances during the application lifetime, this should be treated as an error, because a gauge
+ * must always be bound to just one object, therefore creating multiple instances of the bean would
+ * create ambiguity.
+ */
+@RunWith(Arquillian.class)
+public class GaugeInDependentScopedBeanTest {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addClass(DependentScopedBeanWithGauge.class);
+    }
+
+    @After
+    public void cleanupApplicationMetrics() {
+        MetricRegistries.get(MetricRegistry.Type.APPLICATION).removeMatching(MetricFilter.ALL);
+    }
+
+    @Inject
+    private Instance<DependentScopedBeanWithGauge> beanInstance;
+
+    @Test
+    public void gauge() {
+        try {
+            DependentScopedBeanWithGauge instance1 = beanInstance.get();
+            DependentScopedBeanWithGauge instance2 = beanInstance.get();
+            Assert.fail("Shouldn't be able to create multiple instances of a bean that contains a gauge");
+        } catch(Exception e) {
+
+        }
+    }
+
+}

--- a/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/dependentscoped/MetricsInDependentScopedBeanTest.java
+++ b/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/dependentscoped/MetricsInDependentScopedBeanTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.swarm.microprofile.metrics.dependentscoped;
+
+import io.smallrye.metrics.MetricRegistries;
+import org.eclipse.microprofile.metrics.MetricFilter;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Verify that it is possible to have metrics (except gauges) in beans with other scope than just ApplicationScope.
+ * If there are multiple instances of the bean, the metrics should be automatically added up together over all instances.
+ * They don't need to be marked as reusable for this.
+ * This does not work for gauges because a gauge must always be bound to just one object.
+ */
+@RunWith(Arquillian.class)
+public class MetricsInDependentScopedBeanTest {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addClass(DependentScopedBeanWithMetrics.class);
+    }
+
+    @AfterClass
+    public static void cleanupApplicationMetrics() {
+        MetricRegistries.get(MetricRegistry.Type.APPLICATION).removeMatching(MetricFilter.ALL);
+    }
+
+    @Inject
+    private Instance<DependentScopedBeanWithMetrics> beanInstance;
+
+    @Inject
+    private MetricRegistry registry;
+
+    @Test
+    public void counter() {
+        DependentScopedBeanWithMetrics instance1 = beanInstance.get();
+        DependentScopedBeanWithMetrics instance2 = beanInstance.get();
+
+        instance1.countedMethod();
+        instance2.countedMethod();
+
+        assertEquals(2, registry.getCounters().get("counter").getCount());
+    }
+
+    @Test
+    public void meter() {
+        DependentScopedBeanWithMetrics instance1 = beanInstance.get();
+        DependentScopedBeanWithMetrics instance2 = beanInstance.get();
+
+        instance1.meteredMethod();
+        instance2.meteredMethod();
+
+        assertEquals(2, registry.getMeters().get("meter").getCount());
+    }
+
+    @Test
+    public void timer() {
+        DependentScopedBeanWithMetrics instance1 = beanInstance.get();
+        DependentScopedBeanWithMetrics instance2 = beanInstance.get();
+
+        instance1.timedMethod();
+        instance2.timedMethod();
+
+        assertEquals(2, registry.getTimers().get("timer").getCount());
+    }
+
+}

--- a/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_Counter_ClassLevel_Test.java
+++ b/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_Counter_ClassLevel_Test.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.wildfly.swarm.microprofile.metrics.initialization;
+
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Arquillian.class)
+public class Initialization_Counter_ClassLevel_Test {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addClasses(BeanWithCounter_ClassLevel.class);
+    }
+
+    @Inject
+    MetricRegistry registry;
+
+    @Test
+    public void test() {
+        // metric should be created for the constructor
+        assertTrue(registry.getCounters().containsKey("customName.BeanWithCounter_ClassLevel"));
+
+        // metrics should be created for public methods
+        assertTrue(registry.getCounters().containsKey("customName.publicMethod"));
+        assertTrue(registry.getCounters().containsKey("customName.publicMethod2"));
+
+        // but not for private methods
+        assertFalse(registry.getCounters().keySet().stream().anyMatch(metric -> metric.toLowerCase().contains("private")));
+    }
+
+    @Counted(name = "customName", tags = "t1=v1", absolute = true)
+    private static class BeanWithCounter_ClassLevel {
+
+        public BeanWithCounter_ClassLevel() {
+
+        }
+
+        public void publicMethod() {
+
+        }
+
+        public void publicMethod2() {
+
+        }
+
+        private void privateMethod() {
+
+        }
+
+    }
+
+}

--- a/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_Counter_Constructor_Test.java
+++ b/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_Counter_Constructor_Test.java
@@ -1,0 +1,51 @@
+package org.wildfly.swarm.microprofile.metrics.initialization;
+
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(Arquillian.class)
+public class Initialization_Counter_Constructor_Test {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addClasses(BeanWithCounter_Constructor.class);
+    }
+
+    @Inject
+    MetricRegistry registry;
+
+    @Test
+    public void test() {
+        Counter metricFromConstructor = registry.getCounters()
+                .get("org.wildfly.swarm.microprofile.metrics.initialization.Initialization_Counter_Constructor_Test" +
+                        "$BeanWithCounter_Constructor.BeanWithCounter_Constructor");
+        assertNotNull(metricFromConstructor);
+        assertEquals(1, registry.getCounters().size());
+    }
+
+    private static class BeanWithCounter_Constructor {
+
+        @Counted
+        public BeanWithCounter_Constructor() {
+
+        }
+
+    }
+
+
+}

--- a/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_Counter_Method_Reusable_Test.java
+++ b/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_Counter_Method_Reusable_Test.java
@@ -1,0 +1,65 @@
+package org.wildfly.swarm.microprofile.metrics.initialization;
+
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.annotation.security.PermitAll;
+import javax.inject.Inject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Arquillian.class)
+public class Initialization_Counter_Method_Reusable_Test {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addClasses(BeanWithCounter_Method_Reusable.class);
+    }
+
+    @Inject
+    private MetricRegistry registry;
+
+    @Inject
+    private BeanWithCounter_Method_Reusable bean;
+
+    @Test
+    public void test() {
+        assertTrue(registry.getCounters().containsKey("counter_method"));
+        assertTrue(registry.getCounters((name, metric) -> name.contains("irrelevant")).isEmpty());
+        bean.counterMethod();
+        assertEquals(1, registry.getCounters().get("counter_method").getCount());
+        bean.counterMethod2();
+        assertEquals(2, registry.getCounters().get("counter_method").getCount());
+        assertEquals(1, registry.getCounters().size());
+    }
+
+    public static class BeanWithCounter_Method_Reusable {
+
+        @Counted(name = "counter_method", absolute = true, reusable = true, monotonic = true)
+        public void counterMethod() {
+
+        }
+
+        @Counted(name = "counter_method", absolute = true, reusable = true, monotonic = true)
+        public void counterMethod2() {
+
+        }
+
+        @PermitAll
+        public void irrelevantAnnotatedMethod() {
+
+        }
+
+    }
+
+}

--- a/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_Counter_Method_Test.java
+++ b/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_Counter_Method_Test.java
@@ -1,0 +1,59 @@
+package org.wildfly.swarm.microprofile.metrics.initialization;
+
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.annotation.security.PermitAll;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Arquillian.class)
+public class Initialization_Counter_Method_Test {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addClasses(BeanWithCounter_Method.class);
+    }
+
+    @Inject
+    MetricRegistry registry;
+
+    @Inject
+    BeanWithCounter_Method bean;
+
+    @Test
+    public void test() {
+        assertTrue(registry.getCounters().containsKey("counter_method"));
+        assertTrue(registry.getCounters((name, metric) -> name.contains("irrelevant")).isEmpty());
+        bean.counterMethod();
+        Assert.assertEquals(1, registry.getCounters().get("counter_method").getCount());
+    }
+
+    @ApplicationScoped
+    public static class BeanWithCounter_Method {
+
+        @Counted(name = "counter_method", absolute = true, monotonic = true)
+        public void counterMethod() {
+
+        }
+
+        @PermitAll
+        public void irrelevantAnnotatedMethod() {
+
+        }
+
+    }
+
+}

--- a/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_Gauge_Method_Test.java
+++ b/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_Gauge_Method_Test.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.wildfly.swarm.microprofile.metrics.initialization;
+
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricUnits;
+import org.eclipse.microprofile.metrics.annotation.Gauge;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Arquillian.class)
+public class Initialization_Gauge_Method_Test {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addClasses(BeanWithGauge_ApplicationScoped.class);
+    }
+
+    @Inject
+    MetricRegistry registry;
+
+    @Inject
+    BeanWithGauge_ApplicationScoped applicationScopedBean;
+
+
+    /**
+     * With a gauge in an application-scoped bean, the metric will be registered once the bean is instantiated.
+     */
+    @Test
+    public void testApplicationScoped() {
+        applicationScopedBean.gauge(); // access the application-scoped bean so that an instance gets created
+        assertTrue(registry.getGauges().containsKey("gaugeApp"));
+        Assert.assertEquals(2L, registry.getGauges().get("gaugeApp").getValue());
+        Assert.assertEquals(3L, registry.getGauges().get("gaugeApp").getValue());
+    }
+
+    @ApplicationScoped
+    public static class BeanWithGauge_ApplicationScoped {
+
+        Long i = 0L;
+
+        @Gauge(name = "gaugeApp", absolute = true, unit = MetricUnits.NONE)
+        public Long gauge() {
+            return ++i;
+        }
+
+    }
+
+}

--- a/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_Injection_Test.java
+++ b/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_Injection_Test.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.wildfly.swarm.microprofile.metrics.initialization;
+
+import org.eclipse.microprofile.metrics.Histogram;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.annotation.Metric;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Arquillian.class)
+public class Initialization_Injection_Test {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addClasses(BeanWithMetricInjection.class);
+    }
+
+    @Inject
+    MetricRegistry registry;
+
+    @Inject
+    BeanWithMetricInjection bean;
+
+    @Test
+    public void test() {
+        String name = "org.wildfly.swarm.microprofile.metrics.initialization.Initialization_Injection_Test$BeanWithMetricInjection.histogram";
+        // check that the injected histogram is registered eagerly
+        assertTrue(registry.getHistograms().containsKey(name));
+        bean.addDataToHistogram();
+        assertEquals(10, registry.getHistograms().get(name).getSnapshot().getMax());
+    }
+
+    public static class BeanWithMetricInjection {
+
+        @Inject
+        @Metric
+        Histogram histogram;
+
+        public void addDataToHistogram() {
+            histogram.update(10);
+        }
+
+    }
+
+}

--- a/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_Meter_Method_Test.java
+++ b/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_Meter_Method_Test.java
@@ -1,0 +1,51 @@
+package org.wildfly.swarm.microprofile.metrics.initialization;
+
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.annotation.Metered;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Arquillian.class)
+public class Initialization_Meter_Method_Test {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addClasses(BeanWithMeter_Method.class);
+    }
+
+    @Inject
+    MetricRegistry registry;
+
+    @Inject
+    BeanWithMeter_Method bean;
+
+    @Test
+    public void test() {
+        assertTrue(registry.getMeters().containsKey("meter_method"));
+        bean.meterMethod();
+        assertEquals(1, registry.getMeters().get("meter_method").getCount());
+    }
+
+    public static class BeanWithMeter_Method {
+
+        @Metered(name = "meter_method", absolute = true)
+        public void meterMethod() {
+
+        }
+
+    }
+
+
+}

--- a/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_ProducerField_Test.java
+++ b/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_ProducerField_Test.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.wildfly.swarm.microprofile.metrics.initialization;
+
+import io.smallrye.metrics.app.CounterImpl;
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.annotation.Metric;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Arquillian.class)
+public class Initialization_ProducerField_Test {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addClasses(BeanWithMetricProducerField.class);
+    }
+
+    @Inject
+    MetricRegistry registry;
+
+    @Inject
+    BeanWithMetricProducerField bean;
+
+    @Test
+    public void test() {
+        String name = "counter1";
+        // check eager initialization here
+        assertTrue(registry.getCounters().containsKey(name));
+        assertEquals(0, registry.getCounters().get(name).getCount());
+        bean.addDataToCounter();
+        Counter counter = registry.getCounters().get(name);
+        assertEquals(1, counter.getCount());
+    }
+
+    public static class BeanWithMetricProducerField {
+
+        @Inject
+        MetricRegistry registry;
+
+        @Produces
+        @ApplicationScoped
+        @Metric(name = "counter1", absolute = true)
+        Counter c1 = new CounterImpl();
+
+        public void addDataToCounter() {
+            registry.getCounters().get("counter1").inc();
+        }
+
+    }
+
+}

--- a/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_ProducerMethod_Test.java
+++ b/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_ProducerMethod_Test.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.wildfly.swarm.microprofile.metrics.initialization;
+
+import io.smallrye.metrics.app.CounterImpl;
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.annotation.Metric;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Arquillian.class)
+public class Initialization_ProducerMethod_Test {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addClasses(BeanWithMetricProducerMethod.class);
+    }
+
+    @Inject
+    MetricRegistry registry;
+
+    @Inject
+    BeanWithMetricProducerMethod bean;
+
+    @Test
+    public void test() {
+        String name = "c1";
+        assertTrue(registry.getCounters().containsKey(name));
+        assertEquals(111, registry.getCounters().get(name).getCount());
+    }
+
+    public static class BeanWithMetricProducerMethod {
+
+        // a Counter that always returns 111
+        @Produces
+        @Metric(name = "c1", absolute = true)
+        public Counter producer() {
+            return new CounterImpl() {
+                @Override
+                public long getCount() {
+                    return 111;
+                }
+            };
+        }
+
+    }
+
+}

--- a/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_Timer_Method_Test.java
+++ b/testsuite/extra/src/test/java/org/wildfly/swarm/microprofile/metrics/initialization/Initialization_Timer_Method_Test.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.wildfly.swarm.microprofile.metrics.initialization;
+
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.annotation.Timed;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Arquillian.class)
+public class Initialization_Timer_Method_Test {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addClasses(BeanWithTimer_Method.class);
+    }
+
+    @Inject
+    MetricRegistry registry;
+
+    @Inject
+    BeanWithTimer_Method bean;
+
+    @Test
+    public void test() {
+        assertTrue(registry.getTimers().containsKey("timed_method"));
+        bean.timedMethod();
+        assertEquals(1, registry.getTimers().get("timed_method").getCount());
+    }
+
+    public static class BeanWithTimer_Method {
+
+        @Timed(name = "timed_method", absolute = true)
+        public void timedMethod() {
+
+        }
+
+    }
+
+}


### PR DESCRIPTION
This moves the responsibility of registering annotated metrics from `MetricsInterceptor` to the CDI extension, so they will be initialized eagerly. This will work in Thorntail and WildFly.

Because Quarkus does not support CDI extensions and needs to mimic this somehow, this PR also refactors `MetricMetadata` (which is a class used for metric registration) in a way that it will accept new classes which have no dependency on CDI or `java.lang.reflect` classes - these are `BeanInfo`, `MethodInfo`, `AnnotationInfo`. 

The idea is that each runtime which includes SmallRye Metrics will use an adapter to create instances of these classes - Thorntail and WildFly will use the `CDI*Adapter` classes (which are included here as well) to register metrics within the CDI extension, Quarkus will use the `RawBeanInfo`, `RawMethodInfo` and `RawAnnotationInfo` classes for this (there will be an adapter in Quarkus which turns relevant parts of the Jandex index into instances of these classes, the created instances will then be passed to the `SmallRyeMetricsTemplate` which will then take care of registering the metrics).

Included is also test coverage to verify that eager registration via CDI extension works correctly.

@mkouba please have a look if this makes sense to you. 
If we proceed with this, I'd like to get this released in SR-M 1.1.4 and then upgrade Quarkus to use this. 