### PR TITLE
Reduce the log level in JmxWorker

### DIFF
--- a/implementation/src/main/java/io/smallrye/metrics/JmxWorker.java
+++ b/implementation/src/main/java/io/smallrye/metrics/JmxWorker.java
@@ -170,7 +170,7 @@ public class JmxWorker {
         }
         entries.removeAll(toBeRemoved);
         entries.addAll(result);
-        log.info("Converted [" + toBeRemoved.size() + "] config entries and added [" + result.size() + "] replacements");
+        log.debug("Converted [" + toBeRemoved.size() + "] config entries and added [" + result.size() + "] replacements");
     }
 
     private Map<String,String> findKeyForValueToBeReplaced(ObjectName objectName) {


### PR DESCRIPTION
This relates to issue https://github.com/smallrye/smallrye-metrics/issues/131

The commit here changes a `log.info` to `log.debug` to reduce the messages that show up when the `JmxWorker` logs out a message about the replacements that it created for config entries.

