### PR TITLE
Properly parse Accept headers without q-value. Fixes #151

### DIFF
--- a/implementation/src/main/java/io/smallrye/metrics/MetricsRequestHandler.java
+++ b/implementation/src/main/java/io/smallrye/metrics/MetricsRequestHandler.java
@@ -244,10 +244,8 @@ public class MetricsRequestHandler {
             String[] headers = h.split(",");
             for (String header : headers) {
                 String[] parts = header.split(";");
-                float prio = 0;
-                if (parts.length == 1) {
-                    prio = 1.0f;
-                } else {
+                float prio = 1.0f;
+                if (parts.length > 1) {
                     for (String x : parts) {
                         if (x.startsWith("q=")) {
                             prio = Float.parseFloat(x.substring(2));

--- a/implementation/src/test/java/io/smallrye/metrics/MediaHandlerTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/MediaHandlerTest.java
@@ -130,4 +130,20 @@ public class MediaHandlerTest {
         assertThat(res.get()).isEqualTo("text/plain");
     }
 
+    @Test
+    public void testWithMissingPrioritySingle() {
+        Optional<String> res = requestHandler.getBestMatchingMediaType(Stream.of("application/json;charset=UTF-8"));
+        assertThat(res.isPresent()).isTrue();
+        assertThat(res.get()).isEqualTo("application/json");
+    }
+
+    @Test
+    public void testWithMissingPriorityMulti() {
+        // default q=1 so json should be preferred
+        Optional<String> res = requestHandler.getBestMatchingMediaType(Stream.of("text/plain;q=0.8;charset=UTF-8",
+                "application/json;charset=UTF-8"));
+        assertThat(res.isPresent()).isTrue();
+        assertThat(res.get()).isEqualTo("application/json");
+    }
+
 }


### PR DESCRIPTION
Backport of https://github.com/smallrye/smallrye-metrics/pull/152 to metrics 2.0-1.1.x