### PR TITLE
Add configuration to put microprofile scope in OpenMetrics tag

### DIFF
--- a/implementation/src/test/java/io/smallrye/metrics/app/WeightedSnapshotTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/app/WeightedSnapshotTest.java
@@ -1,10 +1,10 @@
 package io.smallrye.metrics.app;
 
-import org.junit.Test;
+import static org.junit.Assert.*;
 
 import java.util.Collections;
 
-import static org.junit.Assert.*;
+import org.junit.Test;
 
 /**
  * @author helloween


### PR DESCRIPTION
Add a `smallrye.metrics.usePrefixForScope` configuration property
(`true` by default) that specifies whether the microprofile scope
(`base`, `vendor` or `application`) must be prefixed to the OpenMetrics
name or added to the metric's tags (with the key `microprofile_scope`).

This allows applications that were already providing metrics in
Prometheus/OpenMetrics to switch to smallrye-metrics to expose their
metrics while keeping the same names for metrics.