### PR TITLE
Properly handle CDI beans in the default package. Fixes #164

### DIFF
--- a/implementation/src/main/java/io/smallrye/metrics/setup/MetricCdiInjectionExtension.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/MetricCdiInjectionExtension.java
@@ -148,7 +148,8 @@ public class MetricCdiInjectionExtension implements Extension {
     }
 
     private <X> void findAnnotatedMethods(@Observes ProcessManagedBean<X> bean) {
-        if (bean.getBean().getBeanClass().getPackage().equals(MetricsInterceptor.class.getPackage())) {
+        Package pack = bean.getBean().getBeanClass().getPackage();
+        if (pack != null && pack.equals(MetricsInterceptor.class.getPackage())) {
             return;
         }
         ArrayList<AnnotatedMember<?>> list = new ArrayList<>();


### PR DESCRIPTION
backport of https://github.com/smallrye/smallrye-metrics/pull/165 to 2.1.x