### PR TITLE
[2.1.x] [#176] Update ExtendedMetadata to configure scope

### DIFF
--- a/implementation/src/main/java/io/smallrye/metrics/ExtendedMetadata.java
+++ b/implementation/src/main/java/io/smallrye/metrics/ExtendedMetadata.java
@@ -17,6 +17,7 @@
 package io.smallrye.metrics;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import org.eclipse.microprofile.metrics.DefaultMetadata;
 import org.eclipse.microprofile.metrics.MetricType;
@@ -26,22 +27,40 @@ import org.eclipse.microprofile.metrics.MetricType;
  */
 public class ExtendedMetadata extends DefaultMetadata {
 
-    private String mbean;
-    boolean multi;
+    private final String mbean;
+    private final boolean multi;
+    /**
+     * Optional configuration to prepend the microprofile scope to the metric name
+     * when it is exported to the OpenMetrics format.
+     *
+     * By default, the option is empty() and will not be taken into account.
+     * If true, the scope is prepended to the metric name when the OpenMetrics name is generated (e.g. {@code vendor_foo}.
+     * If false, the scope is added to the metric tags instead (e.g. foo{microprofile_scope="vendor"}.
+     *
+     * This option has precedence over the global configuration
+     * {@link io.smallrye.metrics.exporters.OpenMetricsExporter#SMALLRYE_METRICS_USE_PREFIX_FOR_SCOPE}.
+     */
+    private final Optional<Boolean> prependsScopeToOpenMetricsName;
 
     public ExtendedMetadata(String name, MetricType type) {
         this(name, null, null, type, null, null, false);
     }
 
     public ExtendedMetadata(String name, String displayName, String description, MetricType typeRaw, String unit) {
-        this(name, displayName, description, typeRaw, unit, null, false);
+        this(name, displayName, description, typeRaw, unit, null, false, Optional.empty());
     }
 
     public ExtendedMetadata(String name, String displayName, String description, MetricType typeRaw, String unit, String mbean,
             boolean multi) {
+        this(name, displayName, description, typeRaw, unit, mbean, multi, Optional.empty());
+    }
+
+    public ExtendedMetadata(String name, String displayName, String description, MetricType typeRaw, String unit, String mbean,
+            boolean multi, Optional<Boolean> prependsScopeToOpenMetricsName) {
         super(name, displayName, description, typeRaw, unit, false);
         this.mbean = mbean;
         this.multi = multi;
+        this.prependsScopeToOpenMetricsName = prependsScopeToOpenMetricsName;
     }
 
     public String getMbean() {
@@ -50,6 +69,10 @@ public class ExtendedMetadata extends DefaultMetadata {
 
     public boolean isMulti() {
         return multi;
+    }
+
+    public Optional<Boolean> prependsScopeToOpenMetricsName() {
+        return prependsScopeToOpenMetricsName;
     }
 
     @Override
@@ -65,11 +88,12 @@ public class ExtendedMetadata extends DefaultMetadata {
         }
         ExtendedMetadata that = (ExtendedMetadata) o;
         return multi == that.multi &&
+                Objects.equals(prependsScopeToOpenMetricsName, that.prependsScopeToOpenMetricsName) &&
                 Objects.equals(mbean, that.mbean);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), mbean, multi);
+        return Objects.hash(super.hashCode(), mbean, multi, prependsScopeToOpenMetricsName);
     }
 }

--- a/implementation/src/main/java/io/smallrye/metrics/exporters/OpenMetricsExporter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/exporters/OpenMetricsExporter.java
@@ -41,6 +41,7 @@ import org.eclipse.microprofile.metrics.Snapshot;
 import org.eclipse.microprofile.metrics.Timer;
 import org.jboss.logging.Logger;
 
+import io.smallrye.metrics.ExtendedMetadata;
 import io.smallrye.metrics.MetricRegistries;
 
 /**
@@ -323,12 +324,12 @@ public class OpenMetricsExporter implements Exporter {
             boolean performScaling) {
         String name = md.getName();
         name = getOpenMetricsMetricName(name);
-        fillBaseName(sb, scope, name, suffix);
+        fillBaseName(sb, scope, name, suffix, md);
 
         // add tags
 
         if (tags != null) {
-            addTags(sb, tags, scope);
+            addTags(sb, tags, scope, md);
         }
 
         sb.append(SPACE);
@@ -347,10 +348,10 @@ public class OpenMetricsExporter implements Exporter {
 
     }
 
-    private void addTags(StringBuilder sb, Map<String, String> tags, MetricRegistry.Type scope) {
+    private void addTags(StringBuilder sb, Map<String, String> tags, MetricRegistry.Type scope, Metadata metadata) {
         if (tags == null || tags.isEmpty()) {
             // always add the microprofile_scope even if there are no other tags
-            if (!usePrefixForScope) {
+            if (!writeScopeInPrefix(metadata)) {
                 sb.append("{microprofile_scope=\"" + scope.getName().toLowerCase() + "\"}");
             }
             return;
@@ -365,7 +366,7 @@ public class OpenMetricsExporter implements Exporter {
                 }
             }
             // append the microprofile_scope after other tags
-            if (!usePrefixForScope) {
+            if (!writeScopeInPrefix(metadata)) {
                 sb.append(",microprofile_scope=\"" + scope.getName().toLowerCase() + "\"");
             }
 
@@ -377,8 +378,8 @@ public class OpenMetricsExporter implements Exporter {
         return map.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
-    private void fillBaseName(StringBuilder sb, MetricRegistry.Type scope, String key, String suffix) {
-        if (usePrefixForScope) {
+    private void fillBaseName(StringBuilder sb, MetricRegistry.Type scope, String key, String suffix, Metadata metadata) {
+        if (writeScopeInPrefix(metadata)) {
             sb.append(scope.getName().toLowerCase()).append("_");
         }
         sb.append(key);
@@ -390,7 +391,7 @@ public class OpenMetricsExporter implements Exporter {
         // Only write this line if we actually have a description in metadata
         if (writeHelpLine && !md.getDescription().orElse("").isEmpty() && !alreadyExportedNames.get().contains(md.getName())) {
             sb.append("# HELP ");
-            getNameWithScopeAndSuffix(sb, scope, key, suffix);
+            getNameWithScopeAndSuffix(sb, scope, key, suffix, md);
             sb.append(quoteHelpText(md.getDescription().get()));
             sb.append(LF);
         }
@@ -401,7 +402,7 @@ public class OpenMetricsExporter implements Exporter {
             String typeOverride) {
         if (!alreadyExportedNames.get().contains(md.getName())) {
             sb.append("# TYPE ");
-            getNameWithScopeAndSuffix(sb, scope, key, suffix);
+            getNameWithScopeAndSuffix(sb, scope, key, suffix, md);
             if (typeOverride != null) {
                 sb.append(typeOverride);
             } else if (md.getTypeRaw().equals(MetricType.TIMER)) {
@@ -415,8 +416,9 @@ public class OpenMetricsExporter implements Exporter {
         }
     }
 
-    private void getNameWithScopeAndSuffix(StringBuilder sb, MetricRegistry.Type scope, String key, String suffix) {
-        if (usePrefixForScope) {
+    private void getNameWithScopeAndSuffix(StringBuilder sb, MetricRegistry.Type scope, String key, String suffix,
+            Metadata metadata) {
+        if (writeScopeInPrefix(metadata)) {
             sb.append(scope.getName().toLowerCase()).append('_');
         }
         sb.append(getOpenMetricsMetricName(key));
@@ -430,13 +432,13 @@ public class OpenMetricsExporter implements Exporter {
             String suffix, Map<String, String> tags) {
 
         // value line
-        fillBaseName(sb, scope, key, suffix);
+        fillBaseName(sb, scope, key, suffix, md);
         String unit = OpenMetricsUnit.getBaseUnitAsOpenMetricsString(md.getUnit());
         if (!unit.equals(NONE)) {
             sb.append(USCORE).append(unit);
         }
 
-        addTags(sb, tags, scope);
+        addTags(sb, tags, scope, md);
 
         double valIn;
         if (md.getTypeRaw().equals(MetricType.GAUGE)) {
@@ -462,6 +464,15 @@ public class OpenMetricsExporter implements Exporter {
         out = out.replace(":_", ":");
 
         return out;
+    }
+
+    private boolean writeScopeInPrefix(Metadata metadata) {
+        if (metadata instanceof ExtendedMetadata) {
+            ExtendedMetadata extendedMetadata = (ExtendedMetadata) metadata;
+            return extendedMetadata.prependsScopeToOpenMetricsName().orElse(usePrefixForScope);
+        } else {
+            return usePrefixForScope;
+        }
     }
 
     public static String quoteHelpText(String value) {


### PR DESCRIPTION
The prependsScopeToOpenMetricsName can be configure to specify of the
MicroProfile scope must be printed out in the OpenMetrics format on a
metric basis (that has precedence over the global configuration added in

This fixes #176