### PR TITLE
Stop conflating names and keys in alreadyExportedNames map

### DIFF
--- a/implementation/src/main/java/io/smallrye/metrics/exporters/OpenMetricsExporter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/exporters/OpenMetricsExporter.java
@@ -205,7 +205,7 @@ public class OpenMetricsExporter implements Exporter {
                         throw new IllegalArgumentException("Not supported: " + key);
                 }
                 sb.append(metricBuf);
-                alreadyExportedNames.get().add(key);
+                alreadyExportedNames.get().add(md.getName());
             } catch (Exception e) {
                 log.warn("Unable to export metric " + key, e);
             }


### PR DESCRIPTION
#188

This is for master (targeting 2.3.0)