### PR TITLE
Prevent ConcurrentModificationException in MetricRegistryImpl

### DIFF
--- a/implementation/src/main/java/io/smallrye/metrics/MetricsRegistryImpl.java
+++ b/implementation/src/main/java/io/smallrye/metrics/MetricsRegistryImpl.java
@@ -556,7 +556,7 @@ public class MetricsRegistryImpl extends MetricRegistry {
     }
 
     @Override
-    public Map<String, Metadata> getMetadata() {
+    public synchronized Map<String, Metadata> getMetadata() {
         return new HashMap<>(metadataMap);
     }
 }


### PR DESCRIPTION
Backport of https://github.com/smallrye/smallrye-metrics/pull/193 to 2.1.x for WildFly