### PR TITLE
Fix potential NPE in getPackageName

### DIFF
--- a/implementation/src/main/java/io/smallrye/metrics/elementdesc/adapter/cdi/CDIBeanInfo.java
+++ b/implementation/src/main/java/io/smallrye/metrics/elementdesc/adapter/cdi/CDIBeanInfo.java
@@ -28,9 +28,11 @@ import io.smallrye.metrics.elementdesc.BeanInfo;
 public class CDIBeanInfo implements BeanInfo {
 
     private final Class<?> input;
+    private final Package pkg;
 
     CDIBeanInfo(Class<?> input) {
         this.input = input;
+        this.pkg = input.getPackage();
     }
 
     @Override
@@ -40,7 +42,7 @@ public class CDIBeanInfo implements BeanInfo {
 
     @Override
     public String getPackageName() {
-        return input.getPackage().getName();
+        return pkg == null ? null : pkg.getName();
     }
 
     @Override


### PR DESCRIPTION
`Class.getPackage()` can return null, which can then cause a NPE, like it does here https://github.com/quarkusio/quarkus/pull/11656#issuecomment-681926931.

