### PR TITLE
Main updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  ignore:
+  - dependency-name: io.smallrye.config:smallrye-config
+    versions:
+    - 2.1.0

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -11,7 +11,7 @@ jobs:
     name: pre release
 
     steps:
-      - uses: radcortez/project-metadata-action@master
+      - uses: radcortez/project-metadata-action@main
         name: retrieve project metadata
         id: metadata
         with:
@@ -24,7 +24,7 @@ jobs:
           echo '::error::Cannot release a SNAPSHOT version.'
           exit 1
 
-      - uses: radcortez/milestone-review-action@master
+      - uses: radcortez/milestone-review-action@main
         name: milestone review
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       GITHUB_TOKEN: ${{secrets.RELEASE_TOKEN}}
 
     steps:
-      - uses: radcortez/project-metadata-action@master
+      - uses: radcortez/project-metadata-action@main
         name: retrieve project metadata
         id: metadata
         with:
@@ -46,7 +46,7 @@ jobs:
           git push
           git push --tags
 
-      - uses: radcortez/milestone-release-action@master
+      - uses: radcortez/milestone-release-action@main
         name: milestone release
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,7 @@
 :ci: https://github.com/smallrye/smallrye-config/actions?query=workflow%3A%22SmallRye+Build%22
 :sonar: https://sonarcloud.io/dashboard?id=smallrye_smallrye-config
 
-image:https://github.com/smallrye/smallrye-metrics/workflows/SmallRye%20Build/badge.svg?branch=master[link={ci}]
+image:https://github.com/smallrye/smallrye-metrics/workflows/SmallRye%20Build/badge.svg?branch=main[link={ci}]
 image:https://sonarcloud.io/api/project_badges/measure?project=smallrye_smallrye-metrics&metric=alert_status["Quality Gate Status", link={sonar}]
 image:https://img.shields.io/github/license/smallrye/smallrye-metrics.svg["License", link="http://www.apache.org/licenses/LICENSE-2.0"]
 image:https://img.shields.io/maven-central/v/io.smallrye/smallrye-metrics?color=green[]


### PR DESCRIPTION
I renamed `3.0.x` branch to `main`, because `main` used to contain the Micrometer work which we're not continuing, so this PR backports some stuff that didn't go into this branch while `main` was Micrometer