### PR TITLE
Fixes and Misc changes to Micrometer branch

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>smallrye-metrics-parent</artifactId>
         <groupId>io.smallrye</groupId>
-        <version>5.0.1-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.smallrye</groupId>
     <artifactId>smallrye-metrics-parent</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>smallrye-metrics-coverage</artifactId>

--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>io.smallrye</groupId>
     <artifactId>smallrye-metrics-parent</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/implementation/src/main/java/io/smallrye/metrics/elementdesc/adapter/cdi/CDIAnnotationInfo.java
+++ b/implementation/src/main/java/io/smallrye/metrics/elementdesc/adapter/cdi/CDIAnnotationInfo.java
@@ -2,11 +2,8 @@ package io.smallrye.metrics.elementdesc.adapter.cdi;
 
 import java.lang.annotation.Annotation;
 
-import org.eclipse.microprofile.metrics.annotation.ConcurrentGauge;
 import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Gauge;
-import org.eclipse.microprofile.metrics.annotation.Metered;
-import org.eclipse.microprofile.metrics.annotation.SimplyTimed;
 import org.eclipse.microprofile.metrics.annotation.Timed;
 
 import io.smallrye.metrics.SmallRyeMetricsMessages;
@@ -24,16 +21,10 @@ public class CDIAnnotationInfo implements AnnotationInfo {
     public String name() {
         if (annotation instanceof Counted) {
             return ((Counted) annotation).name();
-        } else if (annotation instanceof ConcurrentGauge) {
-            return ((ConcurrentGauge) annotation).name();
         } else if (annotation instanceof Gauge) {
             return ((Gauge) annotation).name();
-        } else if (annotation instanceof Metered) {
-            return ((Metered) annotation).name();
         } else if (annotation instanceof Timed) {
             return ((Timed) annotation).name();
-        } else if (annotation instanceof SimplyTimed) {
-            return ((SimplyTimed) annotation).name();
         } else {
             throw new IllegalArgumentException("Unknown metric annotation type " + annotation.annotationType());
         }
@@ -43,16 +34,10 @@ public class CDIAnnotationInfo implements AnnotationInfo {
     public boolean absolute() {
         if (annotation instanceof Counted) {
             return ((Counted) annotation).absolute();
-        } else if (annotation instanceof ConcurrentGauge) {
-            return ((ConcurrentGauge) annotation).absolute();
         } else if (annotation instanceof Gauge) {
             return ((Gauge) annotation).absolute();
-        } else if (annotation instanceof Metered) {
-            return ((Metered) annotation).absolute();
         } else if (annotation instanceof Timed) {
             return ((Timed) annotation).absolute();
-        } else if (annotation instanceof SimplyTimed) {
-            return ((SimplyTimed) annotation).absolute();
         } else {
             throw SmallRyeMetricsMessages.msg.unknownMetricAnnotationType(annotation.annotationType());
         }
@@ -62,16 +47,10 @@ public class CDIAnnotationInfo implements AnnotationInfo {
     public String[] tags() {
         if (annotation instanceof Counted) {
             return ((Counted) annotation).tags();
-        } else if (annotation instanceof ConcurrentGauge) {
-            return ((ConcurrentGauge) annotation).tags();
         } else if (annotation instanceof Gauge) {
             return ((Gauge) annotation).tags();
-        } else if (annotation instanceof Metered) {
-            return ((Metered) annotation).tags();
         } else if (annotation instanceof Timed) {
             return ((Timed) annotation).tags();
-        } else if (annotation instanceof SimplyTimed) {
-            return ((SimplyTimed) annotation).tags();
         } else {
             throw SmallRyeMetricsMessages.msg.unknownMetricAnnotationType(annotation.annotationType());
         }
@@ -81,16 +60,10 @@ public class CDIAnnotationInfo implements AnnotationInfo {
     public String unit() {
         if (annotation instanceof Counted) {
             return ((Counted) annotation).unit();
-        } else if (annotation instanceof ConcurrentGauge) {
-            return ((ConcurrentGauge) annotation).unit();
         } else if (annotation instanceof Gauge) {
             return ((Gauge) annotation).unit();
-        } else if (annotation instanceof Metered) {
-            return ((Metered) annotation).unit();
         } else if (annotation instanceof Timed) {
             return ((Timed) annotation).unit();
-        } else if (annotation instanceof SimplyTimed) {
-            return ((SimplyTimed) annotation).unit();
         } else {
             throw SmallRyeMetricsMessages.msg.unknownMetricAnnotationType(annotation.annotationType());
         }
@@ -100,16 +73,10 @@ public class CDIAnnotationInfo implements AnnotationInfo {
     public String description() {
         if (annotation instanceof Counted) {
             return ((Counted) annotation).description();
-        } else if (annotation instanceof ConcurrentGauge) {
-            return ((ConcurrentGauge) annotation).description();
         } else if (annotation instanceof Gauge) {
             return ((Gauge) annotation).description();
-        } else if (annotation instanceof Metered) {
-            return ((Metered) annotation).description();
         } else if (annotation instanceof Timed) {
             return ((Timed) annotation).description();
-        } else if (annotation instanceof SimplyTimed) {
-            return ((SimplyTimed) annotation).description();
         } else {
             throw SmallRyeMetricsMessages.msg.unknownMetricAnnotationType(annotation.annotationType());
         }
@@ -119,16 +86,10 @@ public class CDIAnnotationInfo implements AnnotationInfo {
     public String displayName() {
         if (annotation instanceof Counted) {
             return ((Counted) annotation).displayName();
-        } else if (annotation instanceof ConcurrentGauge) {
-            return ((ConcurrentGauge) annotation).displayName();
         } else if (annotation instanceof Gauge) {
             return ((Gauge) annotation).displayName();
-        } else if (annotation instanceof Metered) {
-            return ((Metered) annotation).displayName();
         } else if (annotation instanceof Timed) {
             return ((Timed) annotation).displayName();
-        } else if (annotation instanceof SimplyTimed) {
-            return ((SimplyTimed) annotation).displayName();
         } else {
             throw SmallRyeMetricsMessages.msg.unknownMetricAnnotationType(annotation.annotationType());
         }

--- a/implementation/src/main/java/io/smallrye/metrics/jaxrs/JaxRsMetricsServletFilter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/jaxrs/JaxRsMetricsServletFilter.java
@@ -79,10 +79,11 @@ public class JaxRsMetricsServletFilter implements Filter {
         }
     }
 
+    //TODO: Verify it works properly.
     private void updateAfterSuccess(long startTimestamp, MetricID metricID) {
         long duration = System.nanoTime() - startTimestamp;
         MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.Type.BASE);
-        registry.getSimpleTimer(metricID).update(Duration.ofNanos(duration));
+        registry.getTimer(metricID).update(Duration.ofNanos(duration));
     }
 
     private void updateAfterFailure(MetricID metricID) {
@@ -94,9 +95,10 @@ public class JaxRsMetricsServletFilter implements Filter {
         return new MetricID("REST.request.unmappedException.total", metricID.getTagsAsArray());
     }
 
+    //TODO: Verify it works properly.
     private void createMetrics(MetricID metricID) {
         MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.Type.BASE);
-        if (registry.getSimpleTimer(metricID) == null) {
+        if (registry.getTimer(metricID) == null) {
             Metadata successMetadata = Metadata.builder()
                     .withName(metricID.getName())
                     .withDescription(
@@ -104,7 +106,7 @@ public class JaxRsMetricsServletFilter implements Filter {
                                     "resource method since the start of the server.")
                     .withUnit(MetricUnits.NANOSECONDS)
                     .build();
-            registry.simpleTimer(successMetadata, metricID.getTagsAsArray());
+            registry.timer(successMetadata, metricID.getTagsAsArray());
         }
         MetricID metricIDForFailure = transformToMetricIDForFailedRequest(metricID);
         if (registry.getCounter(metricIDForFailure) == null) {

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/GaugeAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/GaugeAdapter.java
@@ -9,6 +9,7 @@ import org.eclipse.microprofile.metrics.MetricType;
 
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.smallrye.metrics.MetricRegistries;
 
 interface GaugeAdapter<T> extends Gauge<T>, MeterHolder {
 
@@ -26,12 +27,14 @@ interface GaugeAdapter<T> extends Gauge<T>, MeterHolder {
         }
 
         public GaugeAdapter<Double> register(MpMetadata metadata, MetricDescriptor metricInfo, MeterRegistry registry) {
+            MetricRegistries.MP_APP_METER_REG_ACCESS.set(true);
             gauge = io.micrometer.core.instrument.Gauge.builder(metricInfo.name(), obj, f)
                     .description(metadata.getDescription())
                     .tags(metricInfo.tags())
                     .baseUnit(metadata.getUnit())
                     .strongReference(true)
                     .register(registry);
+            MetricRegistries.MP_APP_METER_REG_ACCESS.set(false);
             return this;
         }
 
@@ -63,12 +66,14 @@ interface GaugeAdapter<T> extends Gauge<T>, MeterHolder {
         }
 
         public GaugeAdapter<R> register(MpMetadata metadata, MetricDescriptor metricInfo, MeterRegistry registry) {
+            MetricRegistries.MP_APP_METER_REG_ACCESS.set(true);
             gauge = io.micrometer.core.instrument.Gauge.builder(metricInfo.name(), obj, obj -> f.apply(obj).doubleValue())
                     .description(metadata.getDescription())
                     .tags(metricInfo.tags())
                     .baseUnit(metadata.getUnit())
                     .strongReference(true)
                     .register(registry);
+            MetricRegistries.MP_APP_METER_REG_ACCESS.set(false);
             return this;
         }
 
@@ -99,11 +104,13 @@ interface GaugeAdapter<T> extends Gauge<T>, MeterHolder {
         @Override
         public GaugeAdapter<T> register(MpMetadata metadata, MetricDescriptor metricInfo, MeterRegistry registry) {
             if (gauge == null || metadata.cleanDirtyMetadata()) {
+                MetricRegistries.MP_APP_METER_REG_ACCESS.set(true);
                 gauge = io.micrometer.core.instrument.Gauge.builder(metricInfo.name(), (Supplier<Number>) supplier)
                         .description(metadata.getDescription())
                         .tags(metricInfo.tags())
                         .baseUnit(metadata.getUnit())
                         .strongReference(true).register(registry);
+                MetricRegistries.MP_APP_METER_REG_ACCESS.set(false);
             }
 
             return this;

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/HistogramAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/HistogramAdapter.java
@@ -15,8 +15,13 @@ class HistogramAdapter implements Histogram, MeterHolder {
     HistogramAdapter register(MpMetadata metadata, MetricDescriptor metricInfo, MeterRegistry registry) {
         MetricRegistries.MP_APP_METER_REG_ACCESS.set(true);
         if (summary == null || metadata.cleanDirtyMetadata()) {
-            summary = DistributionSummary.builder(metricInfo.name()).description(metadata.getDescription())
-                    .baseUnit(metadata.getUnit()).tags(metricInfo.tags()).register(registry);
+            summary = DistributionSummary.builder(metricInfo.name())
+            		.description(metadata.getDescription())
+                    .baseUnit(metadata.getUnit())
+                    .tags(metricInfo.tags())
+                    .publishPercentiles(0.5, 0.75, 0.95, 0.98, 0.99, 0.999)
+                    .percentilePrecision(5) //from 0 - 5 , more precision == more memory usage
+                    .register(registry);
         }
         MetricRegistries.MP_APP_METER_REG_ACCESS.set(false);
         return this;

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/HistogramAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/HistogramAdapter.java
@@ -16,7 +16,7 @@ class HistogramAdapter implements Histogram, MeterHolder {
         MetricRegistries.MP_APP_METER_REG_ACCESS.set(true);
         if (summary == null || metadata.cleanDirtyMetadata()) {
             summary = DistributionSummary.builder(metricInfo.name())
-            		.description(metadata.getDescription())
+                    .description(metadata.getDescription())
                     .baseUnit(metadata.getUnit())
                     .tags(metricInfo.tags())
                     .publishPercentiles(0.5, 0.75, 0.95, 0.98, 0.99, 0.999)

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/LegacyMetricRegistryAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/LegacyMetricRegistryAdapter.java
@@ -384,7 +384,7 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
     @Override
     public <T, R extends Number> Gauge<R> gauge(Metadata metadata, T o, Function<T, R> f, Tag... tags) {
         String name = metadata.getName();
-        return internalGauge(internalGetMetadata(name, MetricType.GAUGE),
+        return internalGauge(internalGetMetadata(metadata, MetricType.GAUGE),
                 new MetricDescriptor(name, withAppTags(tags)), o, f);
     }
 
@@ -425,7 +425,7 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
     @Override
     public <T extends Number> Gauge<T> gauge(Metadata metadata, Supplier<T> f, Tag... tags) {
         String name = metadata.getName();
-        return internalGauge(internalGetMetadata(name, MetricType.GAUGE),
+        return internalGauge(internalGetMetadata(metadata, MetricType.GAUGE),
                 new MetricDescriptor(name, withAppTags(tags)), f);
     }
 

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/LegacyMetricRegistryAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/LegacyMetricRegistryAdapter.java
@@ -16,18 +16,15 @@ import java.util.function.Supplier;
 import java.util.function.ToDoubleFunction;
 
 import org.eclipse.microprofile.config.ConfigProvider;
-import org.eclipse.microprofile.metrics.ConcurrentGauge;
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.Gauge;
 import org.eclipse.microprofile.metrics.Histogram;
 import org.eclipse.microprofile.metrics.Metadata;
-import org.eclipse.microprofile.metrics.Meter;
 import org.eclipse.microprofile.metrics.Metric;
 import org.eclipse.microprofile.metrics.MetricFilter;
 import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.MetricType;
-import org.eclipse.microprofile.metrics.SimpleTimer;
 import org.eclipse.microprofile.metrics.Tag;
 import org.eclipse.microprofile.metrics.Timer;
 
@@ -270,21 +267,6 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
     }
 
     @Override
-    public <T extends Metric> T register(String name, T t) throws IllegalArgumentException {
-        throw new UnsupportedOperationException("Can not register a pre-constructed Metric with Micrometer");
-    }
-
-    @Override
-    public <T extends Metric> T register(Metadata metadata, T t) throws IllegalArgumentException {
-        throw new UnsupportedOperationException("Can not register a pre-constructed Metric with Micrometer");
-    }
-
-    @Override
-    public <T extends Metric> T register(Metadata metadata, T t, Tag... tags) throws IllegalArgumentException {
-        throw new UnsupportedOperationException("Can not register a pre-constructed Metric with Micrometer");
-    }
-
-    @Override
     public Counter counter(String name) {
         return internalCounter(internalGetMetadata(name, MetricType.COUNTER),
                 new MetricDescriptor(name, withAppTags()));
@@ -331,31 +313,6 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
                 constructedMeters.computeIfAbsent(id, k -> new CounterAdapter()));
         addNameToApplicationMap(id.toMetricID());
         return result.register(metadata, id, registry);
-    }
-
-    @Override
-    public ConcurrentGauge concurrentGauge(String name) {
-        return null;
-    }
-
-    @Override
-    public ConcurrentGauge concurrentGauge(String name, Tag... tags) {
-        return null;
-    }
-
-    @Override
-    public ConcurrentGauge concurrentGauge(MetricID metricID) {
-        return null;
-    }
-
-    @Override
-    public ConcurrentGauge concurrentGauge(Metadata metadata) {
-        return null;
-    }
-
-    @Override
-    public ConcurrentGauge concurrentGauge(Metadata metadata, Tag... tags) {
-        return null;
     }
 
     public <T> Gauge<Double> gauge(String name, T o, ToDoubleFunction<T> f) {
@@ -494,31 +451,6 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
     }
 
     @Override
-    public Meter meter(String name) {
-        return null;
-    }
-
-    @Override
-    public Meter meter(String name, Tag... tags) {
-        return null;
-    }
-
-    @Override
-    public Meter meter(MetricID metricID) {
-        return null;
-    }
-
-    @Override
-    public Meter meter(Metadata metadata) {
-        return null;
-    }
-
-    @Override
-    public Meter meter(Metadata metadata, Tag... tags) {
-        return null;
-    }
-
-    @Override
     public Timer timer(String name) {
         return internalTimer(internalGetMetadata(name, MetricType.TIMER),
                 new MetricDescriptor(name, withAppTags()));
@@ -568,31 +500,6 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
     }
 
     @Override
-    public SimpleTimer simpleTimer(String name) {
-        return null;
-    }
-
-    @Override
-    public SimpleTimer simpleTimer(String name, Tag... tags) {
-        return null;
-    }
-
-    @Override
-    public SimpleTimer simpleTimer(MetricID metricID) {
-        return null;
-    }
-
-    @Override
-    public SimpleTimer simpleTimer(Metadata metadata) {
-        return null;
-    }
-
-    @Override
-    public SimpleTimer simpleTimer(Metadata metadata, Tag... tags) {
-        return null;
-    }
-
-    @Override
     public Metric getMetric(MetricID metricID) {
         return constructedMeters.get(new MetricDescriptor(metricID.getName(), withAppTags(metricID.getTagsAsArray())));
     }
@@ -610,12 +517,6 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
     }
 
     @Override
-    public ConcurrentGauge getConcurrentGauge(MetricID metricID) {
-        return (ConcurrentGauge) constructedMeters
-                .get(new MetricDescriptor(metricID.getName(), withAppTags(metricID.getTagsAsArray())));
-    }
-
-    @Override
     public Gauge<?> getGauge(MetricID metricID) {
         return (Gauge<?>) constructedMeters
                 .get(new MetricDescriptor(metricID.getName(), withAppTags(metricID.getTagsAsArray())));
@@ -628,30 +529,13 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
     }
 
     @Override
-    public Meter getMeter(MetricID metricID) {
-        return (Meter) constructedMeters.get(new MetricDescriptor(metricID.getName(), withAppTags(metricID.getTagsAsArray())));
-    }
-
-    @Override
     public Timer getTimer(MetricID metricID) {
         return (Timer) constructedMeters.get(new MetricDescriptor(metricID.getName(), withAppTags(metricID.getTagsAsArray())));
     }
 
     @Override
-    public SimpleTimer getSimpleTimer(MetricID metricID) {
-        return (SimpleTimer) constructedMeters
-                .get(new MetricDescriptor(metricID.getName(), withAppTags(metricID.getTagsAsArray())));
-    }
-
-    @Override
     public Metadata getMetadata(String name) {
         return metadataMap.get(name);
-    }
-
-    TimerAdapter injectedSimpleTimer(org.eclipse.microprofile.metrics.annotation.Metric annotation) {
-        return internalSimpleTimer(
-                internalGetMetadata(annotation.name(), MetricType.SIMPLE_TIMER).merge(annotation),
-                new MetricDescriptor(annotation.name(), annotation.tags()));
     }
 
     TimerAdapter internalSimpleTimer(MpMetadata metadata, MetricDescriptor id) {
@@ -750,16 +634,6 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
     }
 
     @Override
-    public SortedMap<MetricID, ConcurrentGauge> getConcurrentGauges() {
-        return getConcurrentGauges(MetricFilter.ALL);
-    }
-
-    @Override
-    public SortedMap<MetricID, ConcurrentGauge> getConcurrentGauges(MetricFilter metricFilter) {
-        return getMetrics(MetricType.CONCURRENT_GAUGE, metricFilter);
-    }
-
-    @Override
     public SortedMap<MetricID, Histogram> getHistograms() {
         return getHistograms(MetricFilter.ALL);
     }
@@ -770,16 +644,6 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
     }
 
     @Override
-    public SortedMap<MetricID, Meter> getMeters() {
-        return getMeters(MetricFilter.ALL);
-    }
-
-    @Override
-    public SortedMap<MetricID, Meter> getMeters(MetricFilter metricFilter) {
-        return getMetrics(MetricType.METERED, metricFilter);
-    }
-
-    @Override
     public SortedMap<MetricID, Timer> getTimers() {
         return getTimers(MetricFilter.ALL);
     }
@@ -787,16 +651,6 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
     @Override
     public SortedMap<MetricID, Timer> getTimers(MetricFilter metricFilter) {
         return getMetrics(MetricType.TIMER, metricFilter);
-    }
-
-    @Override
-    public SortedMap<MetricID, SimpleTimer> getSimpleTimers() {
-        return getSimpleTimers(MetricFilter.ALL);
-    }
-
-    @Override
-    public SortedMap<MetricID, SimpleTimer> getSimpleTimers(MetricFilter metricFilter) {
-        return getMetrics(MetricType.SIMPLE_TIMER, metricFilter);
     }
 
     @Override

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/LegacyMetricsExtension.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/LegacyMetricsExtension.java
@@ -29,11 +29,8 @@ import javax.enterprise.util.AnnotationLiteral;
 
 import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
-import org.eclipse.microprofile.metrics.annotation.ConcurrentGauge;
 import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Gauge;
-import org.eclipse.microprofile.metrics.annotation.Metered;
-import org.eclipse.microprofile.metrics.annotation.SimplyTimed;
 import org.eclipse.microprofile.metrics.annotation.Timed;
 
 import io.smallrye.metrics.MetricProducer;
@@ -114,8 +111,8 @@ public class LegacyMetricsExtension implements Extension {
     /*
      * For classes annotated with metrics (@Counted, etc, add to metricsInterface list - to address cdi injection).
      */
-    private <X> void findAnnotatedInterfaces(@Observes @WithAnnotations({ Counted.class, Gauge.class, Metered.class,
-            SimplyTimed.class, Timed.class, ConcurrentGauge.class }) ProcessAnnotatedType<X> pat) {
+    private <X> void findAnnotatedInterfaces(
+            @Observes @WithAnnotations({ Counted.class, Gauge.class, Timed.class }) ProcessAnnotatedType<X> pat) {
         Class<X> clazz = pat.getAnnotatedType().getJavaClass();
         Package pack = clazz.getPackage();
 

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/TimerAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/TimerAdapter.java
@@ -28,7 +28,12 @@ class TimerAdapter implements org.eclipse.microprofile.metrics.Timer, MeterHolde
     public TimerAdapter register(MpMetadata metadata, MetricDescriptor descriptor) {
         MetricRegistries.MP_APP_METER_REG_ACCESS.set(true);
         if (timer == null || metadata.cleanDirtyMetadata()) {
-            timer = Timer.builder(descriptor.name()).description(metadata.getDescription()).tags(descriptor.tags())
+            timer = Timer
+                    .builder(descriptor.name())
+                    .description(metadata.getDescription())
+                    .tags(descriptor.tags())
+                    .publishPercentiles(0.5, 0.75, 0.95, 0.98, 0.99, 0.999)
+                    .percentilePrecision(5) //from 0 - 5 , more precision == more memory usage
                     .register(registry);
         }
         MetricRegistries.MP_APP_METER_REG_ACCESS.set(false);

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/TimerAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/TimerAdapter.java
@@ -5,7 +5,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.microprofile.metrics.MetricType;
-import org.eclipse.microprofile.metrics.SimpleTimer;
 import org.eclipse.microprofile.metrics.Snapshot;
 
 import io.micrometer.core.instrument.Meter;
@@ -37,9 +36,6 @@ class TimerAdapter implements org.eclipse.microprofile.metrics.Timer, MeterHolde
                     .register(registry);
         }
         MetricRegistries.MP_APP_METER_REG_ACCESS.set(false);
-        if (metadata.type == MetricType.SIMPLE_TIMER) {
-            metricType = MetricType.SIMPLE_TIMER;
-        }
         return this;
     }
 
@@ -79,31 +75,6 @@ class TimerAdapter implements org.eclipse.microprofile.metrics.Timer, MeterHolde
         return timer.count();
     }
 
-    //TODO: remove
-    @Override
-    public double getFifteenMinuteRate() {
-        throw new UnsupportedOperationException("This operation is not supported when used with micrometer");
-    }
-
-    //TODO: remove
-    @Override
-    public double getFiveMinuteRate() {
-        throw new UnsupportedOperationException("This operation is not supported when used with micrometer");
-    }
-
-    //TODO: remove
-    @Override
-    public double getMeanRate() {
-        throw new UnsupportedOperationException("This operation is not supported when used with micrometer");
-    }
-
-    //TODO: remove
-    @Override
-    public double getOneMinuteRate() {
-        throw new UnsupportedOperationException("This operation is not supported when used with micrometer");
-    }
-
-    //TODO: remove
     @Override
     public Snapshot getSnapshot() {
         throw new UnsupportedOperationException("This operation is not supported when used with micrometer");
@@ -122,7 +93,7 @@ class TimerAdapter implements org.eclipse.microprofile.metrics.Timer, MeterHolde
         sample.stop(timer);
     }
 
-    class SampleAdapter implements org.eclipse.microprofile.metrics.Timer.Context, SimpleTimer.Context {
+    class SampleAdapter implements org.eclipse.microprofile.metrics.Timer.Context {
         final Timer timer;
         final Timer.Sample sample;
 

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/interceptors/MetricResolver.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/interceptors/MetricResolver.java
@@ -7,11 +7,8 @@ import javax.enterprise.inject.Vetoed;
 
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.Tag;
-import org.eclipse.microprofile.metrics.annotation.ConcurrentGauge;
 import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Gauge;
-import org.eclipse.microprofile.metrics.annotation.Metered;
-import org.eclipse.microprofile.metrics.annotation.SimplyTimed;
 import org.eclipse.microprofile.metrics.annotation.Timed;
 
 import io.smallrye.metrics.SmallRyeMetricsMessages;
@@ -30,24 +27,12 @@ public class MetricResolver {
         return resolverOf(topClass, element, Counted.class);
     }
 
-    public Of<ConcurrentGauge> concurrentGauge(BeanInfo topClass, MemberInfo element) {
-        return resolverOf(topClass, element, ConcurrentGauge.class);
-    }
-
     public Of<Gauge> gauge(BeanInfo topClass, MemberInfo method) {
         return resolverOf(topClass, method, Gauge.class);
     }
 
-    public Of<Metered> metered(BeanInfo topClass, MemberInfo element) {
-        return resolverOf(topClass, element, Metered.class);
-    }
-
     public Of<Timed> timed(BeanInfo bean, MemberInfo element) {
         return resolverOf(bean, element, Timed.class);
-    }
-
-    public Of<SimplyTimed> simplyTimed(BeanInfo bean, MemberInfo element) {
-        return resolverOf(bean, element, SimplyTimed.class);
     }
 
     private <T extends Annotation> Of<T> resolverOf(BeanInfo bean, MemberInfo element, Class<T> metric) {

--- a/implementation/src/main/java/io/smallrye/metrics/setup/MetricsMetadata.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/MetricsMetadata.java
@@ -3,9 +3,7 @@ package io.smallrye.metrics.setup;
 import static io.smallrye.metrics.legacyapi.TagsUtils.parseTagsAsArray;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Stream;
 
 import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.MetricID;

--- a/implementation/src/main/java/io/smallrye/metrics/setup/MetricsMetadata.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/MetricsMetadata.java
@@ -39,8 +39,7 @@ public class MetricsMetadata {
             registry.counter(metadata, tags);
             if (registry instanceof LegacyMetricRegistryAdapter) {
                 //add this CDI MetricID into MetricRegistry's MetricID list....
-                MetricID metricID = new MetricID(metadata.getName(),
-                        appendScopeTags(tags, (LegacyMetricRegistryAdapter) registry));
+                MetricID metricID = new MetricID(metadata.getName());
                 metricIDs.add(metricID);
 
                 //Some list in MetricRegistry that maps the CDI element, metricID and metric type
@@ -57,8 +56,7 @@ public class MetricsMetadata {
             Tag[] tags = parseTagsAsArray(t.tags());
             registry.timer(metadata, tags);
             if (registry instanceof LegacyMetricRegistryAdapter) {
-                MetricID metricID = new MetricID(metadata.getName(),
-                        appendScopeTags(tags, (LegacyMetricRegistryAdapter) registry));
+                MetricID metricID = new MetricID(metadata.getName());
                 metricIDs.add(metricID);
                 ((LegacyMetricRegistryAdapter) registry).getMemberToMetricMappings().addMetric(element, metricID,
                         MetricType.TIMER);
@@ -75,9 +73,4 @@ public class MetricsMetadata {
                 .withDisplayName(displayName).build();
         return new OriginAndMetadata(origin, metadata);
     }
-
-    private static Tag[] appendScopeTags(Tag[] tags, LegacyMetricRegistryAdapter adapter) {
-        return Stream.concat(Arrays.stream(tags), Arrays.stream(adapter.scopeTagsLegacy())).toArray(Tag[]::new);
-    }
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
   <properties>
     <version.microprofile-config>2.0</version.microprofile-config>
-    <version.microprofile-metrics>3.0</version.microprofile-metrics>
+    <version.microprofile-metrics>5.0.0-SNAPSHOT</version.microprofile-metrics>
 
     <version.micrometer>1.8.5</version.micrometer>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <artifactId>smallrye-metrics-parent</artifactId>
-  <version>5.0.1-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT</version>
 
   <packaging>pom</packaging>
   <name>SmallRye: MicroProfile Metrics Parent</name>

--- a/release/pom.xml
+++ b/release/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-metrics-parent</artifactId>
-        <version>5.0.1-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>smallrye-metrics-release</artifactId>


### PR DESCRIPTION
- Use 5.0.0-SNAPSHOT for version
- Use MP Metrics 5.0.0-SNAPSHOT, see https://github.com/eclipse/microprofile-metrics/pull/664 
- - Remove references to removed metrics
- Fix Missing ThreadLocal usage for Gauges (ThreadLocal used w/ MeterFilter)
- Fix MetricsMetadata appending scope tag (not needed as its appended to meter on micrometer level w/ filter)
- quantiles/percentiles (to be configurable) to Timer and Histogram (DistributionSummary) 
- Fix including mp.metrics.appName into  MetricID passed to MemberMetricMapping metric maps (probably remove this in the future and query/retrieve directly from metric/meter-registry??)

Changes Probably won't pass the SR build as we can't pull 5.0.0-SNAPSHOT from MP Metrics.