### PR TITLE
Issue #506: Use the Eclipse Transformer Plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,25 @@
           </gpgArguments>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.eclipse.transformer</groupId>
+        <artifactId>transformer-maven-plugin</artifactId>
+        <version>0.4.0</version>
+        <configuration>
+          <rules>
+            <jakartaDefaults>true</jakartaDefaults>
+          </rules>
+          <classifier>jakarta</classifier>
+        </configuration>
+        <executions>
+          <execution>
+            <id>default-transform</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
This PR addresses #506 by adding the Eclipse Transformer Maven plugin to provide artifacts that use the `jakarta` namespace as well as the regular artifacts that currently use `javax`.