### PR TITLE
Micrometer more fixes

### DIFF
--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/GaugeAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/GaugeAdapter.java
@@ -9,6 +9,7 @@ import org.eclipse.microprofile.metrics.MetricType;
 
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
 import io.smallrye.metrics.MetricRegistries;
 
 interface GaugeAdapter<T> extends Gauge<T>, MeterHolder {
@@ -33,7 +34,7 @@ interface GaugeAdapter<T> extends Gauge<T>, MeterHolder {
                     .tags(metricInfo.tags())
                     .baseUnit(metadata.getUnit())
                     .strongReference(true)
-                    .register(registry);
+                    .register(Metrics.globalRegistry);
             MetricRegistries.MP_APP_METER_REG_ACCESS.set(false);
             return this;
         }
@@ -72,7 +73,7 @@ interface GaugeAdapter<T> extends Gauge<T>, MeterHolder {
                     .tags(metricInfo.tags())
                     .baseUnit(metadata.getUnit())
                     .strongReference(true)
-                    .register(registry);
+                    .register(Metrics.globalRegistry);
             MetricRegistries.MP_APP_METER_REG_ACCESS.set(false);
             return this;
         }
@@ -109,7 +110,7 @@ interface GaugeAdapter<T> extends Gauge<T>, MeterHolder {
                         .description(metadata.getDescription())
                         .tags(metricInfo.tags())
                         .baseUnit(metadata.getUnit())
-                        .strongReference(true).register(registry);
+                        .strongReference(true).register(Metrics.globalRegistry);
                 MetricRegistries.MP_APP_METER_REG_ACCESS.set(false);
             }
 

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/HistogramAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/HistogramAdapter.java
@@ -7,6 +7,7 @@ import org.eclipse.microprofile.metrics.Snapshot;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
 import io.smallrye.metrics.MetricRegistries;
 
 class HistogramAdapter implements Histogram, MeterHolder {
@@ -21,7 +22,7 @@ class HistogramAdapter implements Histogram, MeterHolder {
                     .tags(metricInfo.tags())
                     .publishPercentiles(0.5, 0.75, 0.95, 0.98, 0.99, 0.999)
                     .percentilePrecision(5) //from 0 - 5 , more precision == more memory usage
-                    .register(registry);
+                    .register(Metrics.globalRegistry);
         }
         MetricRegistries.MP_APP_METER_REG_ACCESS.set(false);
         return this;

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/TimerAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/TimerAdapter.java
@@ -9,6 +9,7 @@ import org.eclipse.microprofile.metrics.Snapshot;
 
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
 import io.smallrye.metrics.MetricRegistries;
 
@@ -33,7 +34,7 @@ class TimerAdapter implements org.eclipse.microprofile.metrics.Timer, MeterHolde
                     .tags(descriptor.tags())
                     .publishPercentiles(0.5, 0.75, 0.95, 0.98, 0.99, 0.999)
                     .percentilePrecision(5) //from 0 - 5 , more precision == more memory usage
-                    .register(registry);
+                    .register(Metrics.globalRegistry);
         }
         MetricRegistries.MP_APP_METER_REG_ACCESS.set(false);
         return this;

--- a/implementation/src/main/java/io/smallrye/metrics/setup/MetricsMetadata.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/MetricsMetadata.java
@@ -69,7 +69,21 @@ public class MetricsMetadata {
             Tag[] tags = parseTagsAsArray(t.tags());
             registry.timer(metadata, tags);
             if (registry instanceof LegacyMetricRegistryAdapter) {
-                MetricID metricID = new MetricID(metadata.getName());
+
+                //FIXME: Temporary, resolve the mp.metrics.appName tag if if available to append to MembersToMetricMapping
+                //so that interceptors can find the annotated metric
+                //Possibly remove MembersToMetricMapping in future, and directly query metric/meter-registry.
+                Tags mmTags = ((LegacyMetricRegistryAdapter) registry).withAppTags(tags);
+
+                List<Tag> mpListTags = new ArrayList<Tag>();
+                mmTags.forEach(tag -> {
+                    Tag mpTag = new Tag(tag.getKey(), tag.getValue());
+                    mpListTags.add(mpTag);
+                });
+
+                Tag[] mpTagArray = mpListTags.toArray(new Tag[0]);
+
+                MetricID metricID = new MetricID(metadata.getName(), mpTagArray);
                 metricIDs.add(metricID);
                 ((LegacyMetricRegistryAdapter) registry).getMemberToMetricMappings().addMetric(element, metricID,
                         MetricType.TIMER);


### PR DESCRIPTION
- Include mp.metrics.appName in `MetricID` when creating metric from @Timed, also for query by forwarding Gauge
- Register/(retrieve) from Global registry in Histogram, Gauge and Timer.