### PR TITLE
Micrometer custom scopes + Gauge number change + Histo/Timer updates + Snapshot updates

### DIFF
--- a/implementation/src/main/java/io/smallrye/metrics/MetricProducer.java
+++ b/implementation/src/main/java/io/smallrye/metrics/MetricProducer.java
@@ -13,6 +13,7 @@ import javax.inject.Inject;
 
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.Gauge;
+import org.eclipse.microprofile.metrics.Histogram;
 import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
@@ -101,6 +102,18 @@ public class MetricProducer {
         //            metricExtension.addMetricId(metricID);
         //        }
         return timer;
+    }
+
+    @Produces
+    Histogram getHistogram(InjectionPoint ip) {
+
+        registry = SharedMetricRegistries.getOrCreate(getScope(ip));
+        Metadata metadata = getMetadata(ip, MetricType.HISTOGRAM);
+        Tag[] tags = getTags(ip);
+
+        Histogram histogram = registry.histogram(metadata, tags);
+
+        return histogram;
     }
 
     private Metadata getMetadata(InjectionPoint ip, MetricType type) {

--- a/implementation/src/main/java/io/smallrye/metrics/MetricProducer.java
+++ b/implementation/src/main/java/io/smallrye/metrics/MetricProducer.java
@@ -45,7 +45,7 @@ public class MetricProducer {
         return () -> {
             // TODO: better error report when the gauge doesn't exist
 
-            registry = MetricRegistries.getOrCreate(getScope(ip));
+            registry = SharedMetricRegistries.getOrCreate(getScope(ip));
             SortedMap<MetricID, Gauge> gauges = registry.getGauges();
 
             String name = metricName.of(ip);
@@ -74,7 +74,7 @@ public class MetricProducer {
     @Produces
     Counter getCounter(InjectionPoint ip) {
 
-        registry = MetricRegistries.getOrCreate(getScope(ip));
+        registry = SharedMetricRegistries.getOrCreate(getScope(ip));
         Metadata metadata = getMetadata(ip, MetricType.COUNTER);
         Tag[] tags = getTags(ip);
 
@@ -90,7 +90,7 @@ public class MetricProducer {
     @Produces
     Timer getTimer(InjectionPoint ip) {
 
-        registry = MetricRegistries.getOrCreate(getScope(ip));
+        registry = SharedMetricRegistries.getOrCreate(getScope(ip));
 
         Metadata metadata = getMetadata(ip, MetricType.TIMER);
         Tag[] tags = getTags(ip);

--- a/implementation/src/main/java/io/smallrye/metrics/MetricProducer.java
+++ b/implementation/src/main/java/io/smallrye/metrics/MetricProducer.java
@@ -48,8 +48,6 @@ public class MetricProducer {
             registry = MetricRegistries.getOrCreate(getScope(ip));
             SortedMap<MetricID, Gauge> gauges = registry.getGauges();
 
-            System.out.println("MetricProducer " + getScope(ip));
-
             String name = metricName.of(ip);
             Tag[] tags = getTags(ip);
 

--- a/implementation/src/main/java/io/smallrye/metrics/MetricProducer.java
+++ b/implementation/src/main/java/io/smallrye/metrics/MetricProducer.java
@@ -31,7 +31,7 @@ import io.smallrye.metrics.legacyapi.interceptors.MetricName;
 @ApplicationScoped
 public class MetricProducer {
 
-    MetricRegistry applicationRegistry = MetricRegistries.getOrCreate(MetricRegistry.Type.APPLICATION);
+    MetricRegistry applicationRegistry = MetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
 
     @Inject
     MetricName metricName;

--- a/implementation/src/main/java/io/smallrye/metrics/MetricRegistryProducer.java
+++ b/implementation/src/main/java/io/smallrye/metrics/MetricRegistryProducer.java
@@ -1,0 +1,31 @@
+package io.smallrye.metrics;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Default;
+import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.spi.InjectionPoint;
+
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.annotation.RegistryType;
+
+@ApplicationScoped
+public class MetricRegistryProducer {
+
+    @Produces
+    @Default
+    public MetricRegistry getMetricRegistry(InjectionPoint ip) {
+
+        RegistryType registryTypeAnnotation = ip.getAnnotated().getAnnotation(RegistryType.class);
+
+        /*
+         * Defaults to "application" scope if no scope parameter value is detected
+         */
+        if (registryTypeAnnotation == null) {
+            return SharedMetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
+        } else {
+            String annoScope = registryTypeAnnotation.scope();
+            return SharedMetricRegistries.getOrCreate(annoScope);
+        }
+    }
+
+}

--- a/implementation/src/main/java/io/smallrye/metrics/MetricRegistryProducer.java
+++ b/implementation/src/main/java/io/smallrye/metrics/MetricRegistryProducer.java
@@ -6,7 +6,7 @@ import javax.enterprise.inject.Produces;
 import javax.enterprise.inject.spi.InjectionPoint;
 
 import org.eclipse.microprofile.metrics.MetricRegistry;
-import org.eclipse.microprofile.metrics.annotation.RegistryType;
+import org.eclipse.microprofile.metrics.annotation.RegistryScope;
 
 @ApplicationScoped
 public class MetricRegistryProducer {
@@ -15,15 +15,15 @@ public class MetricRegistryProducer {
     @Default
     public MetricRegistry getMetricRegistry(InjectionPoint ip) {
 
-        RegistryType registryTypeAnnotation = ip.getAnnotated().getAnnotation(RegistryType.class);
+        RegistryScope registryScopeAnnotation = ip.getAnnotated().getAnnotation(RegistryScope.class);
 
         /*
          * Defaults to "application" scope if no scope parameter value is detected
          */
-        if (registryTypeAnnotation == null) {
+        if (registryScopeAnnotation == null) {
             return SharedMetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
         } else {
-            String annoScope = registryTypeAnnotation.scope();
+            String annoScope = registryScopeAnnotation.scope();
             return SharedMetricRegistries.getOrCreate(annoScope);
         }
     }

--- a/implementation/src/main/java/io/smallrye/metrics/MetricsRequestHandler.java
+++ b/implementation/src/main/java/io/smallrye/metrics/MetricsRequestHandler.java
@@ -96,7 +96,7 @@ public class MetricsRequestHandler {
 
             String metricName = scopePath.substring(scopePath.indexOf('/') + 1);
 
-            MetricRegistry.Type scope = getScopeFromPath(scopePath.substring(0, scopePath.indexOf('/')));
+            String scope = scopePath.substring(0, scopePath.indexOf('/'));
             if (scope == null) {
                 responder.respondWith(404, "Scope " + scopePath + " not found", Collections.emptyMap());
                 return;
@@ -110,7 +110,7 @@ public class MetricsRequestHandler {
             if (registry instanceof LegacyMetricRegistryAdapter &&
                     ((LegacyMetricRegistryAdapter) registry).getPrometheusMeterRegistry().find(metricName).meters()
                             .size() != 0) {
-                output = exporter.exportMetricsByName(scope, metricName);
+                output = exporter.exportMetricsByName(scopePath, metricName);
             } else {
                 responder.respondWith(404, "Metric " + scopePath + " not found", Collections.emptyMap());
                 return;
@@ -119,19 +119,19 @@ public class MetricsRequestHandler {
         } else {
             // A single scope
 
-            MetricRegistry.Type scope = getScopeFromPath(scopePath);
-            if (scope == null) {
+            //MetricRegistry.Type scope = getScopeFromPath(scopePath);
+            if (scopePath == null) {
                 responder.respondWith(404, "Scope " + scopePath + " not found", Collections.emptyMap());
                 return;
             }
 
-            MetricRegistry reg = MetricRegistries.getOrCreate(scope);
+            MetricRegistry reg = MetricRegistries.getOrCreate(scopePath);
 
             //XXX:  Re-evaluate: other types of "MeterRegistries".. prolly not, this is an OM exporter
             //Cast to LegacyMetricRegistryAdapter and check that registry contains meters
             if (reg instanceof LegacyMetricRegistryAdapter &&
                     ((LegacyMetricRegistryAdapter) reg).getPrometheusMeterRegistry().getMeters().size() != 0) {
-                output = exporter.exportOneScope(scope);
+                output = exporter.exportOneScope(scopePath);
             } else {
                 responder.respondWith(204, "No data in scope " + scopePath, Collections.emptyMap());
                 return;
@@ -147,15 +147,15 @@ public class MetricsRequestHandler {
         responder.respondWith(200, output, headers);
     }
 
-    private MetricRegistry.Type getScopeFromPath(String scopePath) throws IOException {
-        MetricRegistry.Type scope;
-        try {
-            scope = MetricRegistry.Type.valueOf(scopePath.toUpperCase());
-        } catch (IllegalArgumentException iae) {
-            return null;
-        }
-        return scope;
-    }
+    //    private MetricRegistry.Type getScopeFromPath(String scopePath) throws IOException {
+    //        MetricRegistry.Type scope;
+    //        try {
+    //            scope = MetricRegistry.Type.valueOf(scopePath.toUpperCase());
+    //        } catch (IllegalArgumentException iae) {
+    //            return null;
+    //        }
+    //        return scope;
+    //    }
 
     /**
      * Determine which exporter we want.

--- a/implementation/src/main/java/io/smallrye/metrics/MetricsRequestHandler.java
+++ b/implementation/src/main/java/io/smallrye/metrics/MetricsRequestHandler.java
@@ -171,7 +171,7 @@ public class MetricsRequestHandler {
         else {
 
             MetricRegistry reg = SharedMetricRegistries.getOrCreate(scope);
-            
+
             // Cast to LegacyMetricRegistryAdapter and check that registry contains meters
             if (reg instanceof LegacyMetricRegistryAdapter
                     && ((LegacyMetricRegistryAdapter) reg).getPrometheusMeterRegistry().getMeters().size() != 0) {

--- a/implementation/src/main/java/io/smallrye/metrics/MetricsRequestHandler.java
+++ b/implementation/src/main/java/io/smallrye/metrics/MetricsRequestHandler.java
@@ -101,7 +101,7 @@ public class MetricsRequestHandler {
                 return;
             }
 
-            MetricRegistry registry = MetricRegistries.getOrCreate(scope);
+            MetricRegistry registry = SharedMetricRegistries.getOrCreate(scope);
 
             //XXX: Better error handling? exceptions?
             if (registry instanceof LegacyMetricRegistryAdapter &&
@@ -121,7 +121,7 @@ public class MetricsRequestHandler {
                 return;
             }
 
-            MetricRegistry reg = MetricRegistries.getOrCreate(scope);
+            MetricRegistry reg = SharedMetricRegistries.getOrCreate(scope);
 
             //XXX:  Re-evaluate: other types of "MeterRegistries".. prolly not, this is an OM exporter
             //Cast to LegacyMetricRegistryAdapter and check that registry contains meters

--- a/implementation/src/main/java/io/smallrye/metrics/MetricsRequestHandler.java
+++ b/implementation/src/main/java/io/smallrye/metrics/MetricsRequestHandler.java
@@ -91,8 +91,7 @@ public class MetricsRequestHandler {
             // All metrics
             output = exporter.exportAllScopes();
 
-        } else if (scopePath.contains("/")) {
-            // One metric name in a scope
+        } else if (scopePath.contains("/")) { // One metric name in a scope
 
             String metricName = scopePath.substring(scopePath.indexOf('/') + 1);
 
@@ -104,36 +103,33 @@ public class MetricsRequestHandler {
 
             MetricRegistry registry = MetricRegistries.getOrCreate(scope);
 
-            // output = exporter.exportMetricsByName(scope, metricName);
-
             //XXX: Better error handling? exceptions?
             if (registry instanceof LegacyMetricRegistryAdapter &&
                     ((LegacyMetricRegistryAdapter) registry).getPrometheusMeterRegistry().find(metricName).meters()
                             .size() != 0) {
-                output = exporter.exportMetricsByName(scopePath, metricName);
+                output = exporter.exportMetricsByName(scope, metricName);
             } else {
                 responder.respondWith(404, "Metric " + scopePath + " not found", Collections.emptyMap());
                 return;
             }
 
-        } else {
-            // A single scope
-
-            //MetricRegistry.Type scope = getScopeFromPath(scopePath);
-            if (scopePath == null) {
-                responder.respondWith(404, "Scope " + scopePath + " not found", Collections.emptyMap());
+        } else { // A single scope
+            //for readability
+            String scope = scopePath;
+            if (scope == null) {
+                responder.respondWith(404, "Scope " + scope + " not found", Collections.emptyMap());
                 return;
             }
 
-            MetricRegistry reg = MetricRegistries.getOrCreate(scopePath);
+            MetricRegistry reg = MetricRegistries.getOrCreate(scope);
 
             //XXX:  Re-evaluate: other types of "MeterRegistries".. prolly not, this is an OM exporter
             //Cast to LegacyMetricRegistryAdapter and check that registry contains meters
             if (reg instanceof LegacyMetricRegistryAdapter &&
                     ((LegacyMetricRegistryAdapter) reg).getPrometheusMeterRegistry().getMeters().size() != 0) {
-                output = exporter.exportOneScope(scopePath);
+                output = exporter.exportOneScope(scope);
             } else {
-                responder.respondWith(204, "No data in scope " + scopePath, Collections.emptyMap());
+                responder.respondWith(204, "No data in scope " + scope, Collections.emptyMap());
                 return;
             }
 
@@ -146,16 +142,6 @@ public class MetricsRequestHandler {
 
         responder.respondWith(200, output, headers);
     }
-
-    //    private MetricRegistry.Type getScopeFromPath(String scopePath) throws IOException {
-    //        MetricRegistry.Type scope;
-    //        try {
-    //            scope = MetricRegistry.Type.valueOf(scopePath.toUpperCase());
-    //        } catch (IllegalArgumentException iae) {
-    //            return null;
-    //        }
-    //        return scope;
-    //    }
 
     /**
      * Determine which exporter we want.

--- a/implementation/src/main/java/io/smallrye/metrics/SharedMetricRegistries.java
+++ b/implementation/src/main/java/io/smallrye/metrics/SharedMetricRegistries.java
@@ -155,6 +155,16 @@ public class SharedMetricRegistries {
     }
 
     /**
+     * Returns true/false if registry with this scope exists
+     * 
+     * @param scope name of scope
+     * @return true/false if registry with this scope exists
+     */
+    public static boolean doesScopeExist(String scope) {
+        return registries.containsKey(scope);
+    }
+
+    /**
      * This will return server level global tag
      * i.e defined in env var or sys props
      *

--- a/implementation/src/main/java/io/smallrye/metrics/base/LegacyBaseMetrics.java
+++ b/implementation/src/main/java/io/smallrye/metrics/base/LegacyBaseMetrics.java
@@ -62,7 +62,7 @@ public class LegacyBaseMetrics implements MeterBinder {
                             " This attribute lists -1 if the collection count is undefined for this collector.")
                     .tag("name",
                             gc.getName())
-                    .register(registry);
+                    .tag("scope", "base").register(registry);
             FunctionCounter.builder("gc.time", gc, GarbageCollectorMXBean::getCollectionTime).description(
                     "Displays the approximate accumulated collection elapsed time in milliseconds. This attribute "
                             +
@@ -75,7 +75,7 @@ public class LegacyBaseMetrics implements MeterBinder {
                             "count has been incremented if the collection elapsed time is very short.")
                     .tag("name",
                             gc.getName())
-                    .register(registry);
+                    .tag("scope", "base").register(registry);
         }
     }
 
@@ -84,15 +84,15 @@ public class LegacyBaseMetrics implements MeterBinder {
         FunctionCounter.builder(TOTAL_LOADED_CLASS_COUNT, classLoadingMXBean, ClassLoadingMXBean::getTotalLoadedClassCount)
                 .description(
                         "Displays the total number of classes that have been loaded since the Java virtual machine has started execution.")
-                .register(registry);
+                .tag("scope", "base").register(registry);
         FunctionCounter.builder(TOTAL_UNLOADED_CLASS_COUNT, classLoadingMXBean, ClassLoadingMXBean::getUnloadedClassCount)
                 .description(
                         "Displays the total number of classes unloaded since the Java virtual machine has started execution.")
-                .register(registry);
+                .tag("scope", "base").register(registry);
         Gauge.builder(CURRENT_LOADED_CLASS_COUNT,
                 classLoadingMXBean::getLoadedClassCount)
                 .description("Displays the number of classes that are currently loaded in the Java virtual machine.")
-                .register(registry);
+                .tag("scope", "base").register(registry);
     }
 
     private void baseOperatingSystemMetrics(MeterRegistry registry) {
@@ -108,12 +108,12 @@ public class LegacyBaseMetrics implements MeterBinder {
                         "This attribute is designed to provide a hint about the system load and may be queried frequently. "
                         +
                         "The load average may be unavailable on some platforms where it is expensive to implement this method.")
-                .register(registry);
+                .tag("scope", "base").register(registry);
         Gauge.builder(CPU_AVAILABLE_PROCESSORS, operatingSystemMXBean::getAvailableProcessors).description(
                 "Displays the number of processors available to the Java virtual machine. This value may change during "
                         +
                         "a particular invocation of the virtual machine.")
-                .register(registry);
+                .tag("scope", "base").register(registry);
 
         // some metrics are only available in jdk internal class 'com.sun.management.OperatingSystemMXBean': cast to it.
         // com.sun.management.OperatingSystemMXBean is not available in SubstrateVM
@@ -136,12 +136,12 @@ public class LegacyBaseMetrics implements MeterBinder {
                                 +
                                 "the JVM process and the whole system. " +
                                 "If the Java Virtual Machine recent CPU usage is not available, the method returns a negative value.")
-                        .baseUnit(BaseUnits.PERCENT).register(registry);
+                        .baseUnit(BaseUnits.PERCENT).tag("scope", "base").register(registry);
 
                 Gauge.builder(PROCESS_CPU_TIME,
                         internalOperatingSystemMXBean::getProcessCpuTime)
                         .description("Displays the CPU time used by the process on which the Java virtual machine is running.")
-                        .baseUnit("").register(registry);
+                        .baseUnit("").tag("scope", "base").register(registry);
             } catch (ClassCastException ignored) {
             }
         }
@@ -152,20 +152,20 @@ public class LegacyBaseMetrics implements MeterBinder {
         Gauge.builder(THREAD_COUNT,
                 thread::getThreadCount)
                 .description("Displays the current number of live threads including both daemon and non-daemon threads")
-                .register(registry);
+                .tag("scope", "base").register(registry);
         Gauge.builder(THREAD_DAEMON_COUNT, thread::getDaemonThreadCount)
-                .description("Displays the current number of live daemon threads.").register(registry);
+                .description("Displays the current number of live daemon threads.").tag("scope", "base").register(registry);
         Gauge.builder(THREAD_MAX_COUNT, thread::getPeakThreadCount)
                 .description("Displays the peak live thread count since the Java virtual machine started or peak was " +
                         "reset. This includes daemon and non-daemon threads.")
-                .register(registry);
+                .tag("scope", "base").register(registry);
     }
 
     private void runtimeMetrics(MeterRegistry registry) {
         RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();
         Gauge.builder(JVM_UPTIME, runtimeMXBean::getUptime)
                 .description("Displays the time from the start of the Java virtual machine in milliseconds.")
-                .register(registry);
+                .tag("scope", "base").register(registry);
     }
 
     private void baseMemoryMetrics(MeterRegistry registry) {
@@ -174,7 +174,7 @@ public class LegacyBaseMetrics implements MeterBinder {
                 memoryMXBean.getHeapMemoryUsage()::getCommitted)
                 .description("Displays the amount of memory in bytes that is committed for the Java virtual machine to use. " +
                         "This amount of memory is guaranteed for the Java virtual machine to use.")
-                .baseUnit(BaseUnits.BYTES).register(registry);
+                .baseUnit(BaseUnits.BYTES).tag("scope", "base").register(registry);
         Gauge.builder(MEMORY_MAX_HEAP,
                 memoryMXBean.getHeapMemoryUsage()::getMax)
                 .description("Displays the maximum amount of heap memory in bytes that can be used for memory management. "
@@ -185,9 +185,9 @@ public class LegacyBaseMetrics implements MeterBinder {
                         +
                         "The Java virtual machine may fail to allocate memory even if the amount of used memory does " +
                         "not exceed this maximum size.")
-                .baseUnit(BaseUnits.BYTES).register(registry);
+                .baseUnit(BaseUnits.BYTES).tag("scope", "base").register(registry);
         Gauge.builder(MEMORY_USED_HEAP,
                 memoryMXBean.getHeapMemoryUsage()::getUsed).description("Displays the amount of used heap memory in bytes.")
-                .baseUnit(BaseUnits.MILLISECONDS).register(registry);
+                .baseUnit(BaseUnits.MILLISECONDS).tag("scope", "base").register(registry);
     }
 }

--- a/implementation/src/main/java/io/smallrye/metrics/base/LegacyBaseMetrics.java
+++ b/implementation/src/main/java/io/smallrye/metrics/base/LegacyBaseMetrics.java
@@ -68,7 +68,7 @@ public class LegacyBaseMetrics implements MeterBinder {
             /*
              * Need to convert from milliseconds to seconds.
              */
-            FunctionCounter.builder("gc.time", gc, gcObj -> (gcObj.getCollectionTime()/1e+3)).description(
+            FunctionCounter.builder("gc.time", gc, gcObj -> (gcObj.getCollectionTime() / 1e+3)).description(
                     "Displays the approximate accumulated collection elapsed time in seconds. This attribute "
                             +
                             "displays -1 if the collection elapsed time is undefined for this collector. The Java "
@@ -146,14 +146,14 @@ public class LegacyBaseMetrics implements MeterBinder {
                         .baseUnit(BaseUnits.PERCENT).tag("scope", "base").register(registry);
                 //TODO: Probably change to RATIO base unit
                 //TODO: Needs to be addressed in a MP Metrics PR first/discussion - do this later.
-                
 
                 /*
                  * Must convert from nanoseconds to seconds.
                  */
                 Gauge.builder(PROCESS_CPU_TIME,
                         () -> (internalOperatingSystemMXBean.getProcessCpuTime() / 1e+9))
-                        .description("Displays the CPU time used by the process on which the Java virtual machine is running in seconds.")
+                        .description(
+                                "Displays the CPU time used by the process on which the Java virtual machine is running in seconds.")
                         .baseUnit(MetricUnits.SECONDS).tag("scope", "base").register(registry);
             } catch (ClassCastException ignored) {
             }
@@ -179,7 +179,7 @@ public class LegacyBaseMetrics implements MeterBinder {
         /*
          * Need to convert from milliseconds to seconds.
          */
-        Gauge.builder(JVM_UPTIME, () -> (runtimeMXBean.getUptime()/1e+3))
+        Gauge.builder(JVM_UPTIME, () -> (runtimeMXBean.getUptime() / 1e+3))
                 .description("Displays the time from the start of the Java virtual machine in seconds.")
                 .baseUnit(MetricUnits.SECONDS)
                 .tag("scope", "base").register(registry);

--- a/implementation/src/main/java/io/smallrye/metrics/elementdesc/AnnotationInfo.java
+++ b/implementation/src/main/java/io/smallrye/metrics/elementdesc/AnnotationInfo.java
@@ -16,4 +16,6 @@ public interface AnnotationInfo {
 
     String annotationName();
 
+    String scope();
+
 }

--- a/implementation/src/main/java/io/smallrye/metrics/elementdesc/RawAnnotationInfo.java
+++ b/implementation/src/main/java/io/smallrye/metrics/elementdesc/RawAnnotationInfo.java
@@ -16,12 +16,14 @@ public class RawAnnotationInfo implements AnnotationInfo {
 
     private String annotationName;
 
+    private String scope;
+
     public RawAnnotationInfo() {
 
     }
 
     public RawAnnotationInfo(String name, boolean absolute, String[] tags, String unit,
-            String description, String displayName, String annotationName) {
+            String description, String displayName, String annotationName, String scope) {
         this.name = name;
         this.absolute = absolute;
         this.tags = tags;
@@ -29,6 +31,7 @@ public class RawAnnotationInfo implements AnnotationInfo {
         this.description = description;
         this.displayName = displayName;
         this.annotationName = annotationName;
+        this.scope = scope;
     }
 
     public String getName() {
@@ -87,6 +90,14 @@ public class RawAnnotationInfo implements AnnotationInfo {
         this.annotationName = annotationName;
     }
 
+    public String getScope() {
+        return scope;
+    }
+
+    public void setScope(String scope) {
+        this.scope = scope;
+    }
+
     @Override
     public String name() {
         return name;
@@ -120,6 +131,11 @@ public class RawAnnotationInfo implements AnnotationInfo {
     @Override
     public String annotationName() {
         return annotationName;
+    }
+
+    @Override
+    public String scope() {
+        return scope;
     }
 
 }

--- a/implementation/src/main/java/io/smallrye/metrics/elementdesc/adapter/cdi/CDIAnnotationInfo.java
+++ b/implementation/src/main/java/io/smallrye/metrics/elementdesc/adapter/cdi/CDIAnnotationInfo.java
@@ -104,4 +104,17 @@ public class CDIAnnotationInfo implements AnnotationInfo {
     public String toString() {
         return annotation.toString();
     }
+
+    @Override
+    public String scope() {
+        if (annotation instanceof Counted) {
+            return ((Counted) annotation).scope();
+        } else if (annotation instanceof Gauge) {
+            return ((Gauge) annotation).scope();
+        } else if (annotation instanceof Timed) {
+            return ((Timed) annotation).scope();
+        } else {
+            throw SmallRyeMetricsMessages.msg.unknownMetricAnnotationType(annotation.annotationType());
+        }
+    }
 }

--- a/implementation/src/main/java/io/smallrye/metrics/exporters/Exporter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/exporters/Exporter.java
@@ -1,8 +1,5 @@
 package io.smallrye.metrics.exporters;
 
-import org.eclipse.microprofile.metrics.MetricID;
-
-// TODO: create Json exporter
 public interface Exporter {
 
     String exportOneScope(String scope);
@@ -11,7 +8,7 @@ public interface Exporter {
 
     String getContentType();
 
-    String exportOneMetric(String scope, MetricID metricID);
+    String exportOneMetricAcrossScopes(String name);
 
     String exportMetricsByName(String scope, String name);
 }

--- a/implementation/src/main/java/io/smallrye/metrics/exporters/Exporter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/exporters/Exporter.java
@@ -1,18 +1,17 @@
 package io.smallrye.metrics.exporters;
 
 import org.eclipse.microprofile.metrics.MetricID;
-import org.eclipse.microprofile.metrics.MetricRegistry;
 
 // TODO: create Json exporter
 public interface Exporter {
 
-    String exportOneScope(MetricRegistry.Type scope);
+    String exportOneScope(String scope);
 
     String exportAllScopes();
 
     String getContentType();
 
-    String exportOneMetric(MetricRegistry.Type scope, MetricID metricID);
+    String exportOneMetric(String scope, MetricID metricID);
 
-    String exportMetricsByName(MetricRegistry.Type scope, String name);
+    String exportMetricsByName(String scope, String name);
 }

--- a/implementation/src/main/java/io/smallrye/metrics/exporters/OpenMetricsExporter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/exporters/OpenMetricsExporter.java
@@ -84,7 +84,7 @@ public class OpenMetricsExporter implements Exporter {
                 meterSuffixSet.add("");
 
                 for (Meter m : meterRegistry.find(name).meters()) {
-                    unitTypesSet.add(m.getId().getBaseUnit());
+                    unitTypesSet.add("_" + m.getId().getBaseUnit());
                     resolveMeterSuffixes(meterSuffixSet, m.getId().getType());
                 }
 

--- a/implementation/src/main/java/io/smallrye/metrics/exporters/OpenMetricsExporter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/exporters/OpenMetricsExporter.java
@@ -35,7 +35,8 @@ public class OpenMetricsExporter implements Exporter {
         for (MeterRegistry meterRegistry : prometheusRegistryList) {
             PrometheusMeterRegistry promMeterRegistry = (PrometheusMeterRegistry) meterRegistry;
             //strip "# EOF"
-            sb.append(promMeterRegistry.scrape(TextFormat.CONTENT_TYPE_OPENMETRICS_100).replaceFirst("\r?\n?# EOF", ""));
+            String scraped = promMeterRegistry.scrape(TextFormat.CONTENT_TYPE_OPENMETRICS_100).replaceFirst("# EOF\r?\n?", "");
+            sb.append(scraped);
         }
         return sb.toString();
     }
@@ -46,7 +47,7 @@ public class OpenMetricsExporter implements Exporter {
         for (MeterRegistry meterRegistry : prometheusRegistryList) {
             MPPrometheusMeterRegistry promMeterRegistry = (MPPrometheusMeterRegistry) meterRegistry;
             if (promMeterRegistry.getScope().equals(scope)) {
-                return promMeterRegistry.scrape(TextFormat.CONTENT_TYPE_OPENMETRICS_100).replaceFirst("\r?\n?# EOF", "");
+                return promMeterRegistry.scrape(TextFormat.CONTENT_TYPE_OPENMETRICS_100).replaceFirst("# EOF\r?\n?", "");
             }
         }
         return null; //FIXME: throw exception, logging?

--- a/implementation/src/main/java/io/smallrye/metrics/exporters/OpenMetricsExporter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/exporters/OpenMetricsExporter.java
@@ -6,7 +6,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.eclipse.microprofile.metrics.MetricID;
-import org.eclipse.microprofile.metrics.MetricRegistry;
 
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Meter.Type;
@@ -43,10 +42,10 @@ public class OpenMetricsExporter implements Exporter {
     }
 
     @Override
-    public String exportOneScope(MetricRegistry.Type scope) {
+    public String exportOneScope(String scope) {
         for (MeterRegistry meterRegistry : prometheusRegistryList) {
             MPPrometheusMeterRegistry promMeterRegistry = (MPPrometheusMeterRegistry) meterRegistry;
-            if (promMeterRegistry.getType() == scope) {
+            if (promMeterRegistry.getScope() == scope) {
                 return promMeterRegistry.scrape(TextFormat.CONTENT_TYPE_OPENMETRICS_100).replaceFirst("\r?\n?# EOF", "");
             }
         }
@@ -57,12 +56,12 @@ public class OpenMetricsExporter implements Exporter {
      * Not used.
      */
     @Override
-    public String exportOneMetric(MetricRegistry.Type scope, MetricID metricID) {
+    public String exportOneMetric(String scope, MetricID metricID) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public String exportMetricsByName(MetricRegistry.Type scope, String name) {
+    public String exportMetricsByName(String scope, String name) {
 
         /**
          * FIXME: Refactor
@@ -76,7 +75,7 @@ public class OpenMetricsExporter implements Exporter {
          */
         for (MeterRegistry meterRegistry : prometheusRegistryList) {
             MPPrometheusMeterRegistry promMeterRegistry = (MPPrometheusMeterRegistry) meterRegistry;
-            if (promMeterRegistry.getType() == scope) {
+            if (promMeterRegistry.getScope() == scope) {
                 Set<String> unitTypesSet = new HashSet<String>();
                 unitTypesSet.add("");
                 Set<String> meterSuffixSet = new HashSet<String>();

--- a/implementation/src/main/java/io/smallrye/metrics/exporters/OpenMetricsExporter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/exporters/OpenMetricsExporter.java
@@ -27,7 +27,6 @@ public class OpenMetricsExporter implements Exporter {
             throw new IllegalStateException("Prometheus registry was not found in the global registry");
             //TODO:  logging
         }
-
     }
 
     @Override
@@ -43,9 +42,10 @@ public class OpenMetricsExporter implements Exporter {
 
     @Override
     public String exportOneScope(String scope) {
+
         for (MeterRegistry meterRegistry : prometheusRegistryList) {
             MPPrometheusMeterRegistry promMeterRegistry = (MPPrometheusMeterRegistry) meterRegistry;
-            if (promMeterRegistry.getScope() == scope) {
+            if (promMeterRegistry.getScope().equals(scope)) {
                 return promMeterRegistry.scrape(TextFormat.CONTENT_TYPE_OPENMETRICS_100).replaceFirst("\r?\n?# EOF", "");
             }
         }
@@ -75,7 +75,8 @@ public class OpenMetricsExporter implements Exporter {
          */
         for (MeterRegistry meterRegistry : prometheusRegistryList) {
             MPPrometheusMeterRegistry promMeterRegistry = (MPPrometheusMeterRegistry) meterRegistry;
-            if (promMeterRegistry.getScope() == scope) {
+
+            if (promMeterRegistry.getScope().equals(scope)) {
                 Set<String> unitTypesSet = new HashSet<String>();
                 unitTypesSet.add("");
                 Set<String> meterSuffixSet = new HashSet<String>();
@@ -87,7 +88,6 @@ public class OpenMetricsExporter implements Exporter {
                 }
 
                 Set<String> scrapeMeterNames = calculateMeterNamesToScrape(name, meterSuffixSet, unitTypesSet);
-
                 //Strip #EOF from output
                 return promMeterRegistry.scrape(TextFormat.CONTENT_TYPE_OPENMETRICS_100, scrapeMeterNames)
                         .replaceFirst("\r?\n?# EOF", "");

--- a/implementation/src/main/java/io/smallrye/metrics/exporters/PrometheusMetricsExporter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/exporters/PrometheusMetricsExporter.java
@@ -15,11 +15,11 @@ import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.prometheus.client.exporter.common.TextFormat;
 import io.smallrye.metrics.setup.MPPrometheusMeterRegistry;
 
-public class OpenMetricsExporter implements Exporter {
+public class PrometheusMetricsExporter implements Exporter {
 
     private final List<MeterRegistry> prometheusRegistryList;
 
-    public OpenMetricsExporter() {
+    public PrometheusMetricsExporter() {
         prometheusRegistryList = Metrics.globalRegistry.getRegistries().stream()
                 .filter(registry -> registry instanceof MPPrometheusMeterRegistry).collect(Collectors.toList());
 
@@ -35,7 +35,7 @@ public class OpenMetricsExporter implements Exporter {
         for (MeterRegistry meterRegistry : prometheusRegistryList) {
             PrometheusMeterRegistry promMeterRegistry = (PrometheusMeterRegistry) meterRegistry;
             //strip "# EOF"
-            String scraped = promMeterRegistry.scrape(TextFormat.CONTENT_TYPE_OPENMETRICS_100).replaceFirst("# EOF\r?\n?", "");
+            String scraped = promMeterRegistry.scrape(TextFormat.CONTENT_TYPE_004).replaceFirst("# EOF\r?\n?", "");
             sb.append(scraped);
         }
         return sb.toString();
@@ -47,7 +47,7 @@ public class OpenMetricsExporter implements Exporter {
         for (MeterRegistry meterRegistry : prometheusRegistryList) {
             MPPrometheusMeterRegistry promMeterRegistry = (MPPrometheusMeterRegistry) meterRegistry;
             if (promMeterRegistry.getScope().equals(scope)) {
-                return promMeterRegistry.scrape(TextFormat.CONTENT_TYPE_OPENMETRICS_100).replaceFirst("# EOF\r?\n?", "");
+                return promMeterRegistry.scrape(TextFormat.CONTENT_TYPE_004).replaceFirst("# EOF\r?\n?", "");
             }
         }
         return null; //FIXME: throw exception, logging?
@@ -90,7 +90,7 @@ public class OpenMetricsExporter implements Exporter {
 
                 Set<String> scrapeMeterNames = calculateMeterNamesToScrape(name, meterSuffixSet, unitTypesSet);
                 //Strip #EOF from output
-                return promMeterRegistry.scrape(TextFormat.CONTENT_TYPE_OPENMETRICS_100, scrapeMeterNames)
+                return promMeterRegistry.scrape(TextFormat.CONTENT_TYPE_004, scrapeMeterNames)
                         .replaceFirst("\r?\n?# EOF", "");
             }
         }

--- a/implementation/src/main/java/io/smallrye/metrics/jaxrs/JaxRsMetricsServletFilter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/jaxrs/JaxRsMetricsServletFilter.java
@@ -82,12 +82,12 @@ public class JaxRsMetricsServletFilter implements Filter {
     //TODO: Verify it works properly.
     private void updateAfterSuccess(long startTimestamp, MetricID metricID) {
         long duration = System.nanoTime() - startTimestamp;
-        MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.Type.BASE);
+        MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.BASE_SCOPE);
         registry.getTimer(metricID).update(Duration.ofNanos(duration));
     }
 
     private void updateAfterFailure(MetricID metricID) {
-        MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.Type.BASE);
+        MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.BASE_SCOPE);
         registry.getCounter(transformToMetricIDForFailedRequest(metricID)).inc();
     }
 
@@ -97,7 +97,7 @@ public class JaxRsMetricsServletFilter implements Filter {
 
     //TODO: Verify it works properly.
     private void createMetrics(MetricID metricID) {
-        MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.Type.BASE);
+        MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.BASE_SCOPE);
         if (registry.getTimer(metricID) == null) {
             Metadata successMetadata = Metadata.builder()
                     .withName(metricID.getName())

--- a/implementation/src/main/java/io/smallrye/metrics/jaxrs/JaxRsMetricsServletFilter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/jaxrs/JaxRsMetricsServletFilter.java
@@ -17,7 +17,7 @@ import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.MetricUnits;
 
-import io.smallrye.metrics.MetricRegistries;
+import io.smallrye.metrics.SharedMetricRegistries;
 
 /**
  * For explanation, see javadoc of {@link JaxRsMetricsFilter}
@@ -82,12 +82,12 @@ public class JaxRsMetricsServletFilter implements Filter {
     //TODO: Verify it works properly.
     private void updateAfterSuccess(long startTimestamp, MetricID metricID) {
         long duration = System.nanoTime() - startTimestamp;
-        MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.BASE_SCOPE);
+        MetricRegistry registry = SharedMetricRegistries.getOrCreate(MetricRegistry.BASE_SCOPE);
         registry.getTimer(metricID).update(Duration.ofNanos(duration));
     }
 
     private void updateAfterFailure(MetricID metricID) {
-        MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.BASE_SCOPE);
+        MetricRegistry registry = SharedMetricRegistries.getOrCreate(MetricRegistry.BASE_SCOPE);
         registry.getCounter(transformToMetricIDForFailedRequest(metricID)).inc();
     }
 
@@ -97,7 +97,7 @@ public class JaxRsMetricsServletFilter implements Filter {
 
     //TODO: Verify it works properly.
     private void createMetrics(MetricID metricID) {
-        MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.BASE_SCOPE);
+        MetricRegistry registry = SharedMetricRegistries.getOrCreate(MetricRegistry.BASE_SCOPE);
         if (registry.getTimer(metricID) == null) {
             Metadata successMetadata = Metadata.builder()
                     .withName(metricID.getName())

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/CounterAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/CounterAdapter.java
@@ -6,7 +6,7 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
-import io.smallrye.metrics.MetricRegistries;
+import io.smallrye.metrics.SharedMetricRegistries;
 
 class CounterAdapter implements org.eclipse.microprofile.metrics.Counter, MeterHolder {
 
@@ -14,7 +14,7 @@ class CounterAdapter implements org.eclipse.microprofile.metrics.Counter, MeterH
 
     public CounterAdapter register(MpMetadata metadata, MetricDescriptor descriptor, MeterRegistry registry, String scope) {
 
-        ThreadLocal<Boolean> threadLocal = MetricRegistries.getThreadLocal(scope);
+        ThreadLocal<Boolean> threadLocal = SharedMetricRegistries.getThreadLocal(scope);
         threadLocal.set(true);
         //if we're creating a new counter... or we're "updating" an existing one with new metadata (but this doesnt actually register with micrometer)
         if (counter == null || metadata.cleanDirtyMetadata()) {

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/CounterAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/CounterAdapter.java
@@ -1,16 +1,45 @@
 package io.smallrye.metrics.legacyapi;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.eclipse.microprofile.metrics.MetricType;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Tag;
 import io.smallrye.metrics.SharedMetricRegistries;
 
 class CounterAdapter implements org.eclipse.microprofile.metrics.Counter, MeterHolder {
 
     Counter counter;
+
+    /*
+     * Have to hold on to meta data for get* methods. Due to multiple Prometheus
+     * meter registries being registered to the global composite meter registry with
+     * deny filters used, this can lead to a problem when the composite meter is
+     * retrieving a value of the meter. It will chose the "first" meter registry
+     * associated to the composite meter. This meter registry may have returned a
+     * Noop meter (due it being denied). As a result, querying this composite meter
+     * for a value can return a 0.
+     * 
+     * See SharedMetricRegistries.java for more information.
+     * 
+     * We do not save the prometheus meter regsitry's meter by itself as the
+     * composite meter registry is needed for the getMeter() call which is used by
+     * remove calls that interact with the global meter registry. Or it could be
+     * that the composite meter is needed still to record data.
+     * 
+     * We do not save the prometheus meter registry's meter and the composite meter
+     * registry together as we do not anticipate high usage of explicit get* calls
+     * from the Metric API for the Metric so we save memory in favour of the process
+     * overhead.
+     */
+    MeterRegistry registry;
+    MetricDescriptor descriptor;
+    Set<Tag> tagsSet = new HashSet<Tag>();
 
     public CounterAdapter register(MpMetadata metadata, MetricDescriptor descriptor, MeterRegistry registry, String scope) {
 
@@ -18,11 +47,20 @@ class CounterAdapter implements org.eclipse.microprofile.metrics.Counter, MeterH
         threadLocal.set(true);
         //if we're creating a new counter... or we're "updating" an existing one with new metadata (but this doesnt actually register with micrometer)
         if (counter == null || metadata.cleanDirtyMetadata()) {
+
+            this.registry = registry;
+            this.descriptor = descriptor;
+
+            tagsSet = new HashSet<Tag>();
+            for (Tag t : descriptor.tags()) {
+                tagsSet.add(t);
+            }
+            tagsSet.add(Tag.of("scope", scope));
+
             counter = Counter.builder(descriptor.name())
                     .description(metadata.getDescription())
                     .baseUnit(metadata.getUnit())
-                    .tags(descriptor.tags())
-                    .tags("scope", scope)
+                    .tags(tagsSet)
                     .register(Metrics.globalRegistry);
         }
 
@@ -41,7 +79,15 @@ class CounterAdapter implements org.eclipse.microprofile.metrics.Counter, MeterH
     }
 
     @Override
+    /*
+     * Due to registries that deny regsitration returning no-op and the chance of the composite meter
+     * obtaining the no-oped meter, we need to explicitly query the meter from the prom meter registry
+     */
     public long getCount() {
+        Counter promCounter = registry.find(descriptor.name()).tags(tagsSet).counter();
+        if (promCounter != null) {
+            return (long) promCounter.count();
+        }
         return (long) counter.count();
     }
 

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/CounterAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/CounterAdapter.java
@@ -12,14 +12,17 @@ class CounterAdapter implements org.eclipse.microprofile.metrics.Counter, MeterH
 
     Counter counter;
 
-    public CounterAdapter register(MpMetadata metadata, MetricDescriptor descriptor, MeterRegistry registry) {
-        MetricRegistries.MP_APP_METER_REG_ACCESS.set(true);
+    public CounterAdapter register(MpMetadata metadata, MetricDescriptor descriptor, MeterRegistry registry, String scope) {
+
+        ThreadLocal<Boolean> threadLocal = MetricRegistries.getThreadLocal(scope);
+        threadLocal.set(true);
         //if we're creating a new counter... or we're "updating" an existing one with new metadata (but this doesnt actually register with micrometer)
         if (counter == null || metadata.cleanDirtyMetadata()) {
             counter = Counter.builder(descriptor.name()).description(metadata.getDescription()).baseUnit(metadata.getUnit())
-                    .tags(descriptor.tags()).register(Metrics.globalRegistry);
+                    .tags(descriptor.tags()).tags("scope", scope).register(Metrics.globalRegistry);
         }
-        MetricRegistries.MP_APP_METER_REG_ACCESS.set(false);
+
+        threadLocal.set(false);
         return this;
     }
 

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/CounterAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/CounterAdapter.java
@@ -18,8 +18,12 @@ class CounterAdapter implements org.eclipse.microprofile.metrics.Counter, MeterH
         threadLocal.set(true);
         //if we're creating a new counter... or we're "updating" an existing one with new metadata (but this doesnt actually register with micrometer)
         if (counter == null || metadata.cleanDirtyMetadata()) {
-            counter = Counter.builder(descriptor.name()).description(metadata.getDescription()).baseUnit(metadata.getUnit())
-                    .tags(descriptor.tags()).tags("scope", scope).register(Metrics.globalRegistry);
+            counter = Counter.builder(descriptor.name())
+                    .description(metadata.getDescription())
+                    .baseUnit(metadata.getUnit())
+                    .tags(descriptor.tags())
+                    .tags("scope", scope)
+                    .register(Metrics.globalRegistry);
         }
 
         threadLocal.set(false);

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/GaugeAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/GaugeAdapter.java
@@ -10,7 +10,7 @@ import org.eclipse.microprofile.metrics.MetricType;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
-import io.smallrye.metrics.MetricRegistries;
+import io.smallrye.metrics.SharedMetricRegistries;
 
 interface GaugeAdapter<T> extends Gauge<T>, MeterHolder {
 
@@ -30,7 +30,7 @@ interface GaugeAdapter<T> extends Gauge<T>, MeterHolder {
         public GaugeAdapter<Double> register(MpMetadata metadata, MetricDescriptor metricInfo, MeterRegistry registry,
                 String scope) {
 
-            ThreadLocal<Boolean> threadLocal = MetricRegistries.getThreadLocal(scope);
+            ThreadLocal<Boolean> threadLocal = SharedMetricRegistries.getThreadLocal(scope);
             threadLocal.set(true);
             gauge = io.micrometer.core.instrument.Gauge.builder(metricInfo.name(), obj, f)
                     .description(metadata.getDescription())
@@ -72,7 +72,7 @@ interface GaugeAdapter<T> extends Gauge<T>, MeterHolder {
 
         public GaugeAdapter<R> register(MpMetadata metadata, MetricDescriptor metricInfo, MeterRegistry registry,
                 String scope) {
-            ThreadLocal<Boolean> threadLocal = MetricRegistries.getThreadLocal(scope);
+            ThreadLocal<Boolean> threadLocal = SharedMetricRegistries.getThreadLocal(scope);
 
             threadLocal.set(true);
             gauge = io.micrometer.core.instrument.Gauge.builder(metricInfo.name(), obj, obj -> f.apply(obj).doubleValue())
@@ -115,7 +115,7 @@ interface GaugeAdapter<T> extends Gauge<T>, MeterHolder {
                 String scope) {
             if (gauge == null || metadata.cleanDirtyMetadata()) {
 
-                ThreadLocal<Boolean> threadLocal = MetricRegistries.getThreadLocal(scope);
+                ThreadLocal<Boolean> threadLocal = SharedMetricRegistries.getThreadLocal(scope);
                 threadLocal.set(true);
                 gauge = io.micrometer.core.instrument.Gauge.builder(metricInfo.name(), (Supplier<Number>) supplier)
                         .description(metadata.getDescription())

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/GaugeAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/GaugeAdapter.java
@@ -15,7 +15,7 @@ import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tag;
 import io.smallrye.metrics.SharedMetricRegistries;
 
-interface GaugeAdapter<T> extends Gauge<T>, MeterHolder {
+interface GaugeAdapter<T extends Number> extends Gauge<T>, MeterHolder {
 
     GaugeAdapter<T> register(MpMetadata metadata, MetricDescriptor metricInfo, MeterRegistry registry, String scope);
 
@@ -24,32 +24,6 @@ interface GaugeAdapter<T> extends Gauge<T>, MeterHolder {
 
         final S obj;
         final ToDoubleFunction<S> f;
-
-        /*
-         * Have to hold on to meta data for get* methods. Due to multiple Prometheus
-         * meter registries being registered to the global composite meter registry with
-         * deny filters used, this can lead to a problem when the composite meter is
-         * retrieving a value of the meter. It will chose the "first" meter registry
-         * associated to the composite meter. This meter registry may have returned a
-         * Noop meter (due it being denied). As a result, querying this composite meter
-         * for a value can return a 0.
-         * 
-         * See SharedMetricRegistries.java for more information.
-         * 
-         * We do not save the prometheus meter regsitry's meter by itself as the
-         * composite meter registry is needed for the getMeter() call which is used by
-         * remove calls that interact with the global meter registry. Or it could be
-         * that the composite meter is needed still to record data.
-         * 
-         * We do not save the prometheus meter registry's meter and the composite meter
-         * registry together as we do not anticipate high usage of explicit get* calls
-         * from the Metric API for the Metric so we save memory in favour of the process
-         * overhead.
-         */
-        MeterRegistry registry;
-        MetricDescriptor descriptor;
-        String scope;
-        Set<Tag> tagsSet = new HashSet<Tag>();
 
         DoubleFunctionGauge(S obj, ToDoubleFunction<S> f) {
             this.obj = obj;
@@ -62,25 +36,15 @@ interface GaugeAdapter<T> extends Gauge<T>, MeterHolder {
             ThreadLocal<Boolean> threadLocal = SharedMetricRegistries.getThreadLocal(scope);
             threadLocal.set(true);
 
-            /*
-             * Save metadata to this Adapter
-             * for use with getValue()
-             */
-            this.registry = registry;
-            this.descriptor = metricInfo;
-
-            tagsSet = new HashSet<Tag>();
+            Set<Tag> tagsSet = new HashSet<Tag>();
             for (Tag t : metricInfo.tags()) {
                 tagsSet.add(t);
             }
             tagsSet.add(Tag.of("scope", scope));
 
             gauge = io.micrometer.core.instrument.Gauge.builder(metricInfo.name(), obj, f)
-                    .description(metadata.getDescription())
-                    .tags(tagsSet)
-                    .baseUnit(metadata.getUnit())
-                    .strongReference(true)
-                    .register(Metrics.globalRegistry);
+                    .description(metadata.getDescription()).tags(tagsSet).baseUnit(metadata.getUnit())
+                    .strongReference(true).register(Metrics.globalRegistry);
             threadLocal.set(false);
             return this;
         }
@@ -91,16 +55,13 @@ interface GaugeAdapter<T> extends Gauge<T>, MeterHolder {
         }
 
         @Override
-        /*
-         * Due to registries that deny regsitration returning no-op and the chance of the composite meter
-         * obtaining the no-oped meter, we need to explicitly query the meter from the prom meter registry
-         */
         public Double getValue() {
-            io.micrometer.core.instrument.Gauge promGauge = registry.find(descriptor.name()).tags(tagsSet).gauge();
-            if (promGauge != null) {
-                return promGauge.value();
-            }
-            return gauge.value();
+            /*
+             * We need to cheat to get value if Gauge is removed from registries and we still
+             * have a ref to this (MP) Gauge, we should still be able to retrieve the value
+             * instead of querying the meter registry for non-existing gauge.
+             */
+            return f.applyAsDouble(obj);
         }
 
         @Override
@@ -115,31 +76,6 @@ interface GaugeAdapter<T> extends Gauge<T>, MeterHolder {
         final S obj;
         final Function<S, R> f;
 
-        /*
-         * Have to hold on to meta data for get* methods. Due to multiple Prometheus
-         * meter registries being registered to the global composite meter registry with
-         * deny filters used, this can lead to a problem when the composite meter is
-         * retrieving a value of the meter. It will chose the "first" meter registry
-         * associated to the composite meter. This meter registry may have returned a
-         * Noop meter (due it being denied). As a result, querying this composite meter
-         * for a value can return a 0.
-         * 
-         * See SharedMetricRegistries.java for more information.
-         * 
-         * We do not save the prometheus meter regsitry's meter by itself as the
-         * composite meter registry is needed for the getMeter() call which is used by
-         * remove calls that interact with the global meter registry. Or it could be
-         * that the composite meter is needed still to record data.
-         * 
-         * We do not save the prometheus meter registry's meter and the composite meter
-         * registry together as we do not anticipate high usage of explicit get* calls
-         * from the Metric API for the Metric so we save memory in favour of the process
-         * overhead.
-         */
-        MeterRegistry registry;
-        MetricDescriptor descriptor;
-        Set<Tag> tagsSet = new HashSet<Tag>();
-
         FunctionGauge(S obj, Function<S, R> f) {
             this.obj = obj;
             this.f = f;
@@ -150,25 +86,16 @@ interface GaugeAdapter<T> extends Gauge<T>, MeterHolder {
             ThreadLocal<Boolean> threadLocal = SharedMetricRegistries.getThreadLocal(scope);
             threadLocal.set(true);
 
-            /*
-             * Save metadata to this Adapter
-             * for use with getValue()
-             */
-            this.registry = registry;
-            this.descriptor = metricInfo;
-
-            tagsSet = new HashSet<Tag>();
+            Set<Tag> tagsSet = new HashSet<Tag>();
             for (Tag t : metricInfo.tags()) {
                 tagsSet.add(t);
             }
             tagsSet.add(Tag.of("scope", scope));
 
-            gauge = io.micrometer.core.instrument.Gauge.builder(metricInfo.name(), obj, obj -> f.apply(obj).doubleValue())
-                    .description(metadata.getDescription())
-                    .tags(tagsSet)
-                    .baseUnit(metadata.getUnit())
-                    .strongReference(true)
-                    .register(Metrics.globalRegistry);
+            gauge = io.micrometer.core.instrument.Gauge
+                    .builder(metricInfo.name(), obj, obj -> f.apply(obj).doubleValue())
+                    .description(metadata.getDescription()).tags(tagsSet).baseUnit(metadata.getUnit())
+                    .strongReference(true).register(Metrics.globalRegistry);
             threadLocal.set(false);
             return this;
         }
@@ -179,16 +106,17 @@ interface GaugeAdapter<T> extends Gauge<T>, MeterHolder {
         }
 
         @Override
-        /*
-         * Due to registries that deny regsitration returning no-op and the chance of the composite meter
-         * obtaining the no-oped meter, we need to explicitly query the meter from the prom meter registry
-         */
         public R getValue() {
-            io.micrometer.core.instrument.Gauge promGauge = registry.find(descriptor.name()).tags(tagsSet).gauge();
-            if (promGauge != null) {
-                return (R) (Double) promGauge.value();
-            }
-            return (R) (Double) gauge.value();
+            /*
+             * We need to cheat. Micrometer returns a double. The generic parameter R is a
+             * Number Or possibly any other boxed Number value. Can't cast to R... Since we
+             * already have the object and function... just call it...
+             * 
+             * Also if Gauge is removed from registries and we still have a ref to this (MP)
+             * Gauge, we should still be able to retrieve the value instead of querying the
+             * meter registry for non-existing gauge.
+             */
+            return (R) f.apply(obj);
         }
 
         @Override
@@ -214,11 +142,8 @@ interface GaugeAdapter<T> extends Gauge<T>, MeterHolder {
                 threadLocal.set(true);
 
                 gauge = io.micrometer.core.instrument.Gauge.builder(metricInfo.name(), (Supplier<Number>) supplier)
-                        .description(metadata.getDescription())
-                        .tags(metricInfo.tags())
-                        .tags("scope", scope)
-                        .baseUnit(metadata.getUnit())
-                        .strongReference(true).register(Metrics.globalRegistry);
+                        .description(metadata.getDescription()).tags(metricInfo.tags()).tags("scope", scope)
+                        .baseUnit(metadata.getUnit()).strongReference(true).register(Metrics.globalRegistry);
                 threadLocal.set(false);
             }
 

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/GaugeAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/GaugeAdapter.java
@@ -1,5 +1,7 @@
 package io.smallrye.metrics.legacyapi;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.function.ToDoubleFunction;
@@ -10,6 +12,7 @@ import org.eclipse.microprofile.metrics.MetricType;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Tag;
 import io.smallrye.metrics.SharedMetricRegistries;
 
 interface GaugeAdapter<T> extends Gauge<T>, MeterHolder {
@@ -22,6 +25,32 @@ interface GaugeAdapter<T> extends Gauge<T>, MeterHolder {
         final S obj;
         final ToDoubleFunction<S> f;
 
+        /*
+         * Have to hold on to meta data for get* methods. Due to multiple Prometheus
+         * meter registries being registered to the global composite meter registry with
+         * deny filters used, this can lead to a problem when the composite meter is
+         * retrieving a value of the meter. It will chose the "first" meter registry
+         * associated to the composite meter. This meter registry may have returned a
+         * Noop meter (due it being denied). As a result, querying this composite meter
+         * for a value can return a 0.
+         * 
+         * See SharedMetricRegistries.java for more information.
+         * 
+         * We do not save the prometheus meter regsitry's meter by itself as the
+         * composite meter registry is needed for the getMeter() call which is used by
+         * remove calls that interact with the global meter registry. Or it could be
+         * that the composite meter is needed still to record data.
+         * 
+         * We do not save the prometheus meter registry's meter and the composite meter
+         * registry together as we do not anticipate high usage of explicit get* calls
+         * from the Metric API for the Metric so we save memory in favour of the process
+         * overhead.
+         */
+        MeterRegistry registry;
+        MetricDescriptor descriptor;
+        String scope;
+        Set<Tag> tagsSet = new HashSet<Tag>();
+
         DoubleFunctionGauge(S obj, ToDoubleFunction<S> f) {
             this.obj = obj;
             this.f = f;
@@ -32,10 +61,23 @@ interface GaugeAdapter<T> extends Gauge<T>, MeterHolder {
 
             ThreadLocal<Boolean> threadLocal = SharedMetricRegistries.getThreadLocal(scope);
             threadLocal.set(true);
+
+            /*
+             * Save metadata to this Adapter
+             * for use with getValue()
+             */
+            this.registry = registry;
+            this.descriptor = metricInfo;
+
+            tagsSet = new HashSet<Tag>();
+            for (Tag t : metricInfo.tags()) {
+                tagsSet.add(t);
+            }
+            tagsSet.add(Tag.of("scope", scope));
+
             gauge = io.micrometer.core.instrument.Gauge.builder(metricInfo.name(), obj, f)
                     .description(metadata.getDescription())
-                    .tags(metricInfo.tags())
-                    .tags("scope", scope)
+                    .tags(tagsSet)
                     .baseUnit(metadata.getUnit())
                     .strongReference(true)
                     .register(Metrics.globalRegistry);
@@ -49,7 +91,15 @@ interface GaugeAdapter<T> extends Gauge<T>, MeterHolder {
         }
 
         @Override
+        /*
+         * Due to registries that deny regsitration returning no-op and the chance of the composite meter
+         * obtaining the no-oped meter, we need to explicitly query the meter from the prom meter registry
+         */
         public Double getValue() {
+            io.micrometer.core.instrument.Gauge promGauge = registry.find(descriptor.name()).tags(tagsSet).gauge();
+            if (promGauge != null) {
+                return promGauge.value();
+            }
             return gauge.value();
         }
 
@@ -65,6 +115,31 @@ interface GaugeAdapter<T> extends Gauge<T>, MeterHolder {
         final S obj;
         final Function<S, R> f;
 
+        /*
+         * Have to hold on to meta data for get* methods. Due to multiple Prometheus
+         * meter registries being registered to the global composite meter registry with
+         * deny filters used, this can lead to a problem when the composite meter is
+         * retrieving a value of the meter. It will chose the "first" meter registry
+         * associated to the composite meter. This meter registry may have returned a
+         * Noop meter (due it being denied). As a result, querying this composite meter
+         * for a value can return a 0.
+         * 
+         * See SharedMetricRegistries.java for more information.
+         * 
+         * We do not save the prometheus meter regsitry's meter by itself as the
+         * composite meter registry is needed for the getMeter() call which is used by
+         * remove calls that interact with the global meter registry. Or it could be
+         * that the composite meter is needed still to record data.
+         * 
+         * We do not save the prometheus meter registry's meter and the composite meter
+         * registry together as we do not anticipate high usage of explicit get* calls
+         * from the Metric API for the Metric so we save memory in favour of the process
+         * overhead.
+         */
+        MeterRegistry registry;
+        MetricDescriptor descriptor;
+        Set<Tag> tagsSet = new HashSet<Tag>();
+
         FunctionGauge(S obj, Function<S, R> f) {
             this.obj = obj;
             this.f = f;
@@ -73,12 +148,24 @@ interface GaugeAdapter<T> extends Gauge<T>, MeterHolder {
         public GaugeAdapter<R> register(MpMetadata metadata, MetricDescriptor metricInfo, MeterRegistry registry,
                 String scope) {
             ThreadLocal<Boolean> threadLocal = SharedMetricRegistries.getThreadLocal(scope);
-
             threadLocal.set(true);
+
+            /*
+             * Save metadata to this Adapter
+             * for use with getValue()
+             */
+            this.registry = registry;
+            this.descriptor = metricInfo;
+
+            tagsSet = new HashSet<Tag>();
+            for (Tag t : metricInfo.tags()) {
+                tagsSet.add(t);
+            }
+            tagsSet.add(Tag.of("scope", scope));
+
             gauge = io.micrometer.core.instrument.Gauge.builder(metricInfo.name(), obj, obj -> f.apply(obj).doubleValue())
                     .description(metadata.getDescription())
-                    .tags(metricInfo.tags())
-                    .tags("scope", scope)
+                    .tags(tagsSet)
                     .baseUnit(metadata.getUnit())
                     .strongReference(true)
                     .register(Metrics.globalRegistry);
@@ -92,7 +179,15 @@ interface GaugeAdapter<T> extends Gauge<T>, MeterHolder {
         }
 
         @Override
+        /*
+         * Due to registries that deny regsitration returning no-op and the chance of the composite meter
+         * obtaining the no-oped meter, we need to explicitly query the meter from the prom meter registry
+         */
         public R getValue() {
+            io.micrometer.core.instrument.Gauge promGauge = registry.find(descriptor.name()).tags(tagsSet).gauge();
+            if (promGauge != null) {
+                return (R) (Double) promGauge.value();
+            }
             return (R) (Double) gauge.value();
         }
 
@@ -117,6 +212,7 @@ interface GaugeAdapter<T> extends Gauge<T>, MeterHolder {
 
                 ThreadLocal<Boolean> threadLocal = SharedMetricRegistries.getThreadLocal(scope);
                 threadLocal.set(true);
+
                 gauge = io.micrometer.core.instrument.Gauge.builder(metricInfo.name(), (Supplier<Number>) supplier)
                         .description(metadata.getDescription())
                         .tags(metricInfo.tags())

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/HistogramAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/HistogramAdapter.java
@@ -106,10 +106,13 @@ class HistogramAdapter implements Histogram, MeterHolder {
         return (long) summary.takeSnapshot().total();
     }
 
-    /** TODO: Separate Issue/PR impl Snapshot adapter */
     @Override
     public Snapshot getSnapshot() {
-        throw new UnsupportedOperationException("This operation is not supported when used with micrometer");
+        DistributionSummary promDistSum = registry.find(descriptor.name()).tags(tagsSet).summary();
+        if (promDistSum != null) {
+            return new SnapshotAdapter(promDistSum.takeSnapshot());
+        }
+        return new SnapshotAdapter(summary.takeSnapshot());
     }
 
     @Override

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/HistogramAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/HistogramAdapter.java
@@ -1,5 +1,8 @@
 package io.smallrye.metrics.legacyapi;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.eclipse.microprofile.metrics.Histogram;
 import org.eclipse.microprofile.metrics.MetricType;
 import org.eclipse.microprofile.metrics.Snapshot;
@@ -8,10 +11,36 @@ import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Tag;
 import io.smallrye.metrics.SharedMetricRegistries;
 
 class HistogramAdapter implements Histogram, MeterHolder {
     DistributionSummary summary;
+
+    /*
+     * Have to hold on to meta data for get* methods. Due to multiple Prometheus
+     * meter registries being registered to the global composite meter registry with
+     * deny filters used, this can lead to a problem when the composite meter is
+     * retrieving a value of the meter. It will chose the "first" meter registry
+     * associated to the composite meter. This meter registry may have returned a
+     * Noop meter (due it being denied). As a result, querying this composite meter
+     * for a value can return a 0.
+     * 
+     * See SharedMetricRegistries.java for more information.
+     * 
+     * We do not save the prometheus meter regsitry's meter by itself as the
+     * composite meter registry is needed for the getMeter() call which is used by
+     * remove calls that interact with the global meter registry. Or it could be
+     * that the composite meter is needed still to record data.
+     * 
+     * We do not save the prometheus meter registry's meter and the composite meter
+     * registry together as we do not anticipate high usage of explicit get* calls
+     * from the Metric API for the Metric so we save memory in favour of the process
+     * overhead.
+     */
+    MeterRegistry registry;
+    MetricDescriptor descriptor;
+    Set<Tag> tagsSet = new HashSet<Tag>();
 
     HistogramAdapter register(MpMetadata metadata, MetricDescriptor metricInfo, MeterRegistry registry, String scope) {
 
@@ -19,16 +48,24 @@ class HistogramAdapter implements Histogram, MeterHolder {
 
         threadLocal.set(true);
         if (summary == null || metadata.cleanDirtyMetadata()) {
+
+            this.registry = registry;
+            this.descriptor = metricInfo;
+
+            tagsSet = new HashSet<Tag>();
+            for (Tag t : metricInfo.tags()) {
+                tagsSet.add(t);
+            }
+            tagsSet.add(Tag.of("scope", scope));
+
             summary = DistributionSummary.builder(metricInfo.name())
                     .description(metadata.getDescription())
                     .baseUnit(metadata.getUnit())
-                    .tags(metricInfo.tags())
-                    .tags("scope", scope)
+                    .tags(tagsSet)
                     .publishPercentiles(0.5, 0.75, 0.95, 0.98, 0.99, 0.999)
                     .percentilePrecision(5) //from 0 - 5 , more precision == more memory usage
                     .register(Metrics.globalRegistry);
         }
-
         threadLocal.set(false);
         return this;
     }
@@ -44,18 +81,32 @@ class HistogramAdapter implements Histogram, MeterHolder {
     }
 
     @Override
+    /*
+     * Due to registries that deny regsitration returning no-op and the chance of the composite meter
+     * obtaining the no-oped meter, we need to explicitly query the meter from the prom meter registry
+     */
     public long getCount() {
+        DistributionSummary promDistSum = registry.find(descriptor.name()).tags(tagsSet).summary();
+        if (promDistSum != null) {
+            return (long) promDistSum.count();
+        }
         return summary.count();
     }
 
     @Override
+    /*
+     * Due to registries that deny regsitration returning no-op and the chance of the composite meter
+     * obtaining the no-oped meter, we need to explicitly query the meter from the prom meter registry
+     */
     public long getSum() {
-        throw new UnsupportedOperationException("This operation is not supported when used with micrometer");
-        //If we keep this call.
-        //summary.takeSnapshot().total();
+        DistributionSummary promDistSum = registry.find(descriptor.name()).tags(tagsSet).summary();
+        if (promDistSum != null) {
+            return (long) promDistSum.takeSnapshot().total();
+        }
+        return (long) summary.takeSnapshot().total();
     }
 
-    /** Not supported. */
+    /** TODO: Separate Issue/PR impl Snapshot adapter */
     @Override
     public Snapshot getSnapshot() {
         throw new UnsupportedOperationException("This operation is not supported when used with micrometer");

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/HistogramAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/HistogramAdapter.java
@@ -8,14 +8,14 @@ import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
-import io.smallrye.metrics.MetricRegistries;
+import io.smallrye.metrics.SharedMetricRegistries;
 
 class HistogramAdapter implements Histogram, MeterHolder {
     DistributionSummary summary;
 
     HistogramAdapter register(MpMetadata metadata, MetricDescriptor metricInfo, MeterRegistry registry, String scope) {
 
-        ThreadLocal<Boolean> threadLocal = MetricRegistries.getThreadLocal(scope);
+        ThreadLocal<Boolean> threadLocal = SharedMetricRegistries.getThreadLocal(scope);
 
         threadLocal.set(true);
         if (summary == null || metadata.cleanDirtyMetadata()) {

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/LegacyMetricRegistryAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/LegacyMetricRegistryAdapter.java
@@ -390,7 +390,7 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
     @SuppressWarnings("unchecked")
     <T extends Number> GaugeAdapter<T> internalGauge(MpMetadata metadata, MetricDescriptor id, Supplier<T> f) {
         GaugeAdapter<T> result = checkCast(GaugeAdapter.NumberSupplierGauge.class, metadata,
-                constructedMeters.computeIfAbsent(id, k -> new GaugeAdapter.NumberSupplierGauge<>(f)));
+                constructedMeters.computeIfAbsent(id, k -> new GaugeAdapter.NumberSupplierGauge<T>(f)));
         return result.register(metadata, id, registry, scope);
     }
 
@@ -700,8 +700,10 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
 
         Tags out = Tags.empty();
 
-        for (Tag t : tags) {
-            out = out.and(t.getTagName(), t.getTagValue());
+        if (tags != null) {
+            for (Tag t : tags) {
+                out = out.and(t.getTagName(), t.getTagValue());
+            }
         }
 
         out = combineApplicationTagsWithMPConfigAppNameTag(out);

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/LegacyMetricRegistryAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/LegacyMetricRegistryAdapter.java
@@ -31,7 +31,7 @@ import org.eclipse.microprofile.metrics.Timer;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tags;
-import io.smallrye.metrics.MetricRegistries;
+import io.smallrye.metrics.SharedMetricRegistries;
 import io.smallrye.metrics.setup.ApplicationNameResolver;
 
 public class LegacyMetricRegistryAdapter implements MetricRegistry {
@@ -92,6 +92,7 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
     }
 
     public void unRegisterApplicationMetrics(String appName) {
+
         /*
          * This would be the case if the ApplicationListener30's ApplicatinInfo does not contain
          * the application's deployment name (corrupt application?) or if this MetricRegistry is
@@ -575,7 +576,7 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
         MeterHolder holder = constructedMeters.remove(match);
 
         if (holder != null) {
-            ThreadLocal<Boolean> threadLocal = MetricRegistries.getThreadLocal(scope);
+            ThreadLocal<Boolean> threadLocal = SharedMetricRegistries.getThreadLocal(scope);
 
             threadLocal.set(true);
             io.micrometer.core.instrument.Meter meter = Metrics.globalRegistry.remove(holder.getMeter());

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/LegacyMetricRegistryAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/LegacyMetricRegistryAdapter.java
@@ -539,22 +539,15 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
         return metadataMap.get(name);
     }
 
-    TimerAdapter internalSimpleTimer(MpMetadata metadata, MetricDescriptor id) {
-        // SimpleTimer --> Micrometer Timer
-        TimerAdapter result = checkCast(TimerAdapter.class, metadata,
-                constructedMeters.computeIfAbsent(id, k -> new TimerAdapter(registry)));
-        return result.register(metadata, id, scope);
-    }
-
     @Override
     public boolean remove(String name) {
         for (Map.Entry<MetricDescriptor, MeterHolder> e : constructedMeters.entrySet()) {
             if (e.getKey().name().equals(name)) {
-                constructedMeters.remove(e.getKey());
-                registry.remove(e.getValue().getMeter());
+                return internalRemove(e.getKey());
             }
         }
-        return metadataMap.remove(name) != null;
+        return false;
+
     }
 
     @Override

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/LegacyMetricRegistryAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/LegacyMetricRegistryAdapter.java
@@ -575,22 +575,9 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
         MeterHolder holder = constructedMeters.remove(match);
 
         if (holder != null) {
-
-            //XXX: Since we've been registering to the Global Reg, we need to 
-            //remove from global reg... This involves using the Thread Locals again.
-            //            ThreadLocal<Boolean> tlb = null;
-            //            if (scope.equals(APPLICATION_SCOPE)) {
-            //                tlb = MetricRegistries.MP_APP_METER_REG_ACCESS;
-            //            } else if (scope.equals(BASE_SCOPE)) {
-            //                tlb = MetricRegistries.MP_BASE_METER_REG_ACCESS;
-            //            } else {
-            //                tlb = MetricRegistries.MP_VENDOR_METER_REG_ACCESS;
-            //            }
-
             ThreadLocal<Boolean> threadLocal = MetricRegistries.getThreadLocal(scope);
 
             threadLocal.set(true);
-            //io.micrometer.core.instrument.Meter meter = registry.remove(holder.getMeter());
             io.micrometer.core.instrument.Meter meter = Metrics.globalRegistry.remove(holder.getMeter());
             threadLocal.set(false);
 

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/LegacyMetricsExtension.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/LegacyMetricsExtension.java
@@ -34,8 +34,9 @@ import org.eclipse.microprofile.metrics.annotation.Gauge;
 import org.eclipse.microprofile.metrics.annotation.Timed;
 
 import io.smallrye.metrics.MetricProducer;
-import io.smallrye.metrics.MetricRegistries;
+import io.smallrye.metrics.MetricRegistryProducer;
 import io.smallrye.metrics.MetricsRequestHandler;
+import io.smallrye.metrics.SharedMetricRegistries;
 import io.smallrye.metrics.SmallRyeMetricsLogging;
 import io.smallrye.metrics.elementdesc.adapter.BeanInfoAdapter;
 import io.smallrye.metrics.elementdesc.adapter.cdi.CDIBeanInfoAdapter;
@@ -97,7 +98,7 @@ public class LegacyMetricsExtension implements Extension {
         for (Class clazz : new Class[] {
                 MetricProducer.class,
                 MetricNameFactory.class,
-                MetricRegistries.class,
+                MetricRegistryProducer.class,
                 MetricsRequestHandler.class,
                 CountedInterceptor.class,
                 GaugeRegistrationInterceptor.class,
@@ -170,7 +171,7 @@ public class LegacyMetricsExtension implements Extension {
     void registerMetrics(@Observes AfterDeploymentValidation adv, BeanManager manager) {
 
         // Produce and register custom metrics
-        MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
+        MetricRegistry registry = SharedMetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
         BeanInfoAdapter<Class<?>> beanInfoAdapter = new CDIBeanInfoAdapter();
         CDIMemberInfoAdapter memberInfoAdapter = new CDIMemberInfoAdapter();
         MetricResolver resolver = new MetricResolver();
@@ -216,7 +217,7 @@ public class LegacyMetricsExtension implements Extension {
     }
 
     void unregisterMetrics(@Observes BeforeShutdown shutdown) {
-        MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
+        MetricRegistry registry = SharedMetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
         metricIDs.forEach(metricId -> registry.remove(metricId));
     }
 

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/LegacyMetricsExtension.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/LegacyMetricsExtension.java
@@ -170,7 +170,7 @@ public class LegacyMetricsExtension implements Extension {
     void registerMetrics(@Observes AfterDeploymentValidation adv, BeanManager manager) {
 
         // Produce and register custom metrics
-        MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.Type.APPLICATION);
+        MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
         BeanInfoAdapter<Class<?>> beanInfoAdapter = new CDIBeanInfoAdapter();
         CDIMemberInfoAdapter memberInfoAdapter = new CDIMemberInfoAdapter();
         MetricResolver resolver = new MetricResolver();
@@ -216,7 +216,7 @@ public class LegacyMetricsExtension implements Extension {
     }
 
     void unregisterMetrics(@Observes BeforeShutdown shutdown) {
-        MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.Type.APPLICATION);
+        MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
         metricIDs.forEach(metricId -> registry.remove(metricId));
     }
 

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/SnapshotAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/SnapshotAdapter.java
@@ -1,0 +1,52 @@
+package io.smallrye.metrics.legacyapi;
+
+import java.io.OutputStream;
+import java.io.PrintStream;
+
+import org.eclipse.microprofile.metrics.Snapshot;
+
+import io.micrometer.core.instrument.distribution.HistogramSnapshot;
+import io.micrometer.core.instrument.distribution.ValueAtPercentile;
+
+public class SnapshotAdapter extends Snapshot {
+
+    private HistogramSnapshot histogramSnapshot;
+
+    public SnapshotAdapter(HistogramSnapshot histogramSnapshot) {
+        this.histogramSnapshot = histogramSnapshot;
+    }
+
+    @Override
+    public long size() {
+        return histogramSnapshot.count();
+    }
+
+    @Override
+    public double getMax() {
+        return histogramSnapshot.max();
+    }
+
+    @Override
+    public double getMean() {
+        return histogramSnapshot.mean();
+    }
+
+    @Override
+    public PercentileValue[] percentileValues() {
+        ValueAtPercentile[] valueAtPercentiles = histogramSnapshot.percentileValues();
+        PercentileValue[] percentileValues = new PercentileValue[valueAtPercentiles.length];
+
+        for (int i = 0; i < valueAtPercentiles.length; i++) {
+            percentileValues[i] = new PercentileValue(valueAtPercentiles[i].percentile(), valueAtPercentiles[i].value());
+        }
+
+        return percentileValues;
+    }
+
+    @Override
+    public void dump(OutputStream output) {
+        histogramSnapshot.outputSummary(new PrintStream(output), 1);
+
+    }
+
+}

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/TimerAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/TimerAdapter.java
@@ -11,7 +11,7 @@ import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
-import io.smallrye.metrics.MetricRegistries;
+import io.smallrye.metrics.SharedMetricRegistries;
 
 class TimerAdapter implements org.eclipse.microprofile.metrics.Timer, MeterHolder {
     final MeterRegistry registry;
@@ -27,7 +27,7 @@ class TimerAdapter implements org.eclipse.microprofile.metrics.Timer, MeterHolde
 
     public TimerAdapter register(MpMetadata metadata, MetricDescriptor descriptor, String scope) {
 
-        ThreadLocal<Boolean> threadLocal = MetricRegistries.getThreadLocal(scope);
+        ThreadLocal<Boolean> threadLocal = SharedMetricRegistries.getThreadLocal(scope);
         threadLocal.set(true);
         if (timer == null || metadata.cleanDirtyMetadata()) {
             timer = Timer

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/TimerAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/TimerAdapter.java
@@ -25,18 +25,21 @@ class TimerAdapter implements org.eclipse.microprofile.metrics.Timer, MeterHolde
         this.registry = registry;
     }
 
-    public TimerAdapter register(MpMetadata metadata, MetricDescriptor descriptor) {
-        MetricRegistries.MP_APP_METER_REG_ACCESS.set(true);
+    public TimerAdapter register(MpMetadata metadata, MetricDescriptor descriptor, String scope) {
+
+        ThreadLocal<Boolean> threadLocal = MetricRegistries.getThreadLocal(scope);
+        threadLocal.set(true);
         if (timer == null || metadata.cleanDirtyMetadata()) {
             timer = Timer
                     .builder(descriptor.name())
                     .description(metadata.getDescription())
                     .tags(descriptor.tags())
+                    .tags("scope", scope)
                     .publishPercentiles(0.5, 0.75, 0.95, 0.98, 0.99, 0.999)
                     .percentilePrecision(5) //from 0 - 5 , more precision == more memory usage
                     .register(Metrics.globalRegistry);
         }
-        MetricRegistries.MP_APP_METER_REG_ACCESS.set(false);
+        threadLocal.set(false);
         return this;
     }
 

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/TimerAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/TimerAdapter.java
@@ -125,9 +125,13 @@ class TimerAdapter implements org.eclipse.microprofile.metrics.Timer, MeterHolde
     }
 
     @Override
-    /** TODO: Separate Issue/PR impl Snapshot adapter */
     public Snapshot getSnapshot() {
-        throw new UnsupportedOperationException("This operation is not supported when used with micrometer");
+
+        Timer promTimer = registry.find(descriptor.name()).tags(tagsSet).timer();
+        if (promTimer != null) {
+            return new SnapshotAdapter(promTimer.takeSnapshot());
+        }
+        return new SnapshotAdapter(timer.takeSnapshot());
     }
 
     @Override

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/TimerAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/TimerAdapter.java
@@ -1,6 +1,8 @@
 package io.smallrye.metrics.legacyapi;
 
 import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
@@ -10,16 +12,37 @@ import org.eclipse.microprofile.metrics.Snapshot;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
 import io.smallrye.metrics.SharedMetricRegistries;
 
 class TimerAdapter implements org.eclipse.microprofile.metrics.Timer, MeterHolder {
-    final MeterRegistry registry;
     Timer timer;
 
-    // which MP metric type this adapter represents - this is needed because the same class is used as an adapter for Timer and SimpleTimer
-    // if this is actually a SimpleTimer, this value will be changed to reflect that
-    MetricType metricType = MetricType.TIMER;
+    /*
+     * Have to hold on to meta data for get* methods. Due to multiple Prometheus
+     * meter registries being registered to the global composite meter registry with
+     * deny filters used, this can lead to a problem when the composite meter is
+     * retrieving a value of the meter. It will chose the "first" meter registry
+     * associated to the composite meter. This meter registry may have returned a
+     * Noop meter (due it being denied). As a result, querying this composite meter
+     * for a value can return a 0.
+     * 
+     * See SharedMetricRegistries.java for more information.
+     * 
+     * We do not save the prometheus meter regsitry's meter by itself as the
+     * composite meter registry is needed for the getMeter() call which is used by
+     * remove calls that interact with the global meter registry. Or it could be
+     * that the composite meter is needed still to record data.
+     * 
+     * We do not save the prometheus meter registry's meter and the composite meter
+     * registry together as we do not anticipate high usage of explicit get* calls
+     * from the Metric API for the Metric so we save memory in favour of the process
+     * overhead.
+     */
+    final MeterRegistry registry;
+    MetricDescriptor descriptor;
+    Set<Tag> tagsSet = new HashSet<Tag>();
 
     TimerAdapter(MeterRegistry registry) {
         this.registry = registry;
@@ -30,11 +53,18 @@ class TimerAdapter implements org.eclipse.microprofile.metrics.Timer, MeterHolde
         ThreadLocal<Boolean> threadLocal = SharedMetricRegistries.getThreadLocal(scope);
         threadLocal.set(true);
         if (timer == null || metadata.cleanDirtyMetadata()) {
+
+            this.descriptor = descriptor;
+            tagsSet = new HashSet<Tag>();
+            for (Tag t : descriptor.tags()) {
+                tagsSet.add(t);
+            }
+            tagsSet.add(Tag.of("scope", scope));
+
             timer = Timer
                     .builder(descriptor.name())
                     .description(metadata.getDescription())
-                    .tags(descriptor.tags())
-                    .tags("scope", scope)
+                    .tags(tagsSet)
                     .publishPercentiles(0.5, 0.75, 0.95, 0.98, 0.99, 0.999)
                     .percentilePrecision(5) //from 0 - 5 , more precision == more memory usage
                     .register(Metrics.globalRegistry);
@@ -59,27 +89,43 @@ class TimerAdapter implements org.eclipse.microprofile.metrics.Timer, MeterHolde
 
     @Override
     public void time(Runnable runnable) {
-        timer.wrap(runnable);
+        timer.wrap(runnable).run();
     }
 
     @Override
     public SampleAdapter time() {
-        return new SampleAdapter(timer, Timer.start(registry));
+        return new SampleAdapter(timer, Timer.start(Metrics.globalRegistry));
     }
 
     @Override
+    /*
+     * Due to registries that deny regsitration returning no-op and the chance of the composite meter
+     * obtaining the no-oped meter, we need to explicitly query the meter from the prom meter registry
+     */
     public Duration getElapsedTime() {
-        throw new UnsupportedOperationException("This operation is not supported when used with micrometer");
-        //
-        //timer.takeSnapshot.total();
+        Timer promTimer = registry.find(descriptor.name()).tags(tagsSet).timer();
+        if (promTimer != null) {
+            return Duration.ofNanos((long) promTimer.totalTime(TimeUnit.NANOSECONDS));
+        }
+        return Duration.ofNanos((long) timer.totalTime(TimeUnit.NANOSECONDS));
     }
 
     @Override
+    /*
+     * Due to registries that deny registration returning no-op and the chance of the composite meter
+     * obtaining the no-oped meter, we need to explicitly query the meter from the prom meter registry
+     */
     public long getCount() {
+        Timer promTimer = registry.find(descriptor.name()).tags(tagsSet).timer();
+        if (promTimer != null) {
+            return (long) promTimer.count();
+        }
+
         return timer.count();
     }
 
     @Override
+    /** TODO: Separate Issue/PR impl Snapshot adapter */
     public Snapshot getSnapshot() {
         throw new UnsupportedOperationException("This operation is not supported when used with micrometer");
     }
@@ -119,6 +165,6 @@ class TimerAdapter implements org.eclipse.microprofile.metrics.Timer, MeterHolde
 
     @Override
     public MetricType getType() {
-        return metricType;
+        return MetricType.TIMER;
     }
 }

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/interceptors/CountedInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/interceptors/CountedInterceptor.java
@@ -5,7 +5,6 @@ import java.lang.reflect.Member;
 import java.util.Set;
 
 import javax.annotation.Priority;
-import javax.inject.Inject;
 import javax.interceptor.AroundConstruct;
 import javax.interceptor.AroundInvoke;
 import javax.interceptor.AroundTimeout;
@@ -29,12 +28,7 @@ import io.smallrye.metrics.legacyapi.LegacyMetricRegistryAdapter;
 @Priority(Interceptor.Priority.LIBRARY_BEFORE + 10)
 public class CountedInterceptor {
 
-    private final MetricRegistry registry;
-
-    @Inject
-    CountedInterceptor() {
-        this.registry = MetricRegistries.getOrCreate(MetricRegistry.Type.APPLICATION);
-    }
+    private MetricRegistry registry;
 
     @AroundConstruct
     Object countedConstructor(InvocationContext context) throws Exception {
@@ -53,6 +47,13 @@ public class CountedInterceptor {
 
     private <E extends Member & AnnotatedElement> Object countedCallable(InvocationContext context, E element)
             throws Exception {
+
+        Counted countedAnno = element.getAnnotation(Counted.class);
+        if (countedAnno != null)
+            registry = MetricRegistries.getOrCreate(countedAnno.scope());
+        else
+            registry = MetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
+
         Set<MetricID> ids = ((LegacyMetricRegistryAdapter) registry).getMemberToMetricMappings()
                 .getCounters(new CDIMemberInfoAdapter<>().convert(element));
         if (ids == null || ids.isEmpty()) {

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/interceptors/CountedInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/interceptors/CountedInterceptor.java
@@ -17,7 +17,7 @@ import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.MetricType;
 import org.eclipse.microprofile.metrics.annotation.Counted;
 
-import io.smallrye.metrics.MetricRegistries;
+import io.smallrye.metrics.SharedMetricRegistries;
 import io.smallrye.metrics.SmallRyeMetricsMessages;
 import io.smallrye.metrics.elementdesc.adapter.cdi.CDIMemberInfoAdapter;
 import io.smallrye.metrics.legacyapi.LegacyMetricRegistryAdapter;
@@ -50,9 +50,9 @@ public class CountedInterceptor {
 
         Counted countedAnno = element.getAnnotation(Counted.class);
         if (countedAnno != null)
-            registry = MetricRegistries.getOrCreate(countedAnno.scope());
+            registry = SharedMetricRegistries.getOrCreate(countedAnno.scope());
         else
-            registry = MetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
+            registry = SharedMetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
 
         Set<MetricID> ids = ((LegacyMetricRegistryAdapter) registry).getMemberToMetricMappings()
                 .getCounters(new CDIMemberInfoAdapter<>().convert(element));

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/interceptors/GaugeRegistrationInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/interceptors/GaugeRegistrationInterceptor.java
@@ -66,7 +66,7 @@ public class GaugeRegistrationInterceptor {
         do {
             // TODO: discover annotations declared on implemented interfaces
             for (Method method : type.getDeclaredMethods()) {
-                // TODO: check that the method returns a Number?
+
                 MetricResolver.Of<Gauge> gauge = resolver.gauge(beanInfoAdapter.convert(type),
                         memberInfoAdapter.convert(method));
                 if (gauge.isPresent()) {
@@ -76,6 +76,10 @@ public class GaugeRegistrationInterceptor {
 
                     registry = SharedMetricRegistries.getOrCreate(g.scope());
 
+                    /*
+                     * Error/warning will be emitted by the runtime if return value
+                     * is not a `Number`
+                     */
                     registry.gauge(metadata,
                             context.getTarget(),
                             i -> (Number) invokeMethod(method, i),

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/interceptors/GaugeRegistrationInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/interceptors/GaugeRegistrationInterceptor.java
@@ -30,7 +30,7 @@ import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.MetricType;
 import org.eclipse.microprofile.metrics.annotation.Gauge;
 
-import io.smallrye.metrics.MetricRegistries;
+import io.smallrye.metrics.SharedMetricRegistries;
 import io.smallrye.metrics.elementdesc.AnnotationInfo;
 import io.smallrye.metrics.elementdesc.adapter.BeanInfoAdapter;
 import io.smallrye.metrics.elementdesc.adapter.MemberInfoAdapter;
@@ -74,7 +74,7 @@ public class GaugeRegistrationInterceptor {
                     Metadata metadata = MetricsMetadata.getMetadata(g, gauge.metricName(), g.unit(), g.description(),
                             g.displayName(), MetricType.GAUGE);
 
-                    registry = MetricRegistries.getOrCreate(g.scope());
+                    registry = SharedMetricRegistries.getOrCreate(g.scope());
 
                     registry.gauge(metadata,
                             context.getTarget(),

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/interceptors/GaugeRegistrationInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/interceptors/GaugeRegistrationInterceptor.java
@@ -21,7 +21,6 @@ import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 
 import javax.annotation.Priority;
-import javax.inject.Inject;
 import javax.interceptor.AroundConstruct;
 import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
@@ -31,6 +30,7 @@ import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.MetricType;
 import org.eclipse.microprofile.metrics.annotation.Gauge;
 
+import io.smallrye.metrics.MetricRegistries;
 import io.smallrye.metrics.elementdesc.AnnotationInfo;
 import io.smallrye.metrics.elementdesc.adapter.BeanInfoAdapter;
 import io.smallrye.metrics.elementdesc.adapter.MemberInfoAdapter;
@@ -45,13 +45,11 @@ import io.smallrye.metrics.setup.MetricsMetadata;
 @Priority(Interceptor.Priority.LIBRARY_BEFORE)
 public class GaugeRegistrationInterceptor {
 
-    private final MetricRegistry registry;
+    private MetricRegistry registry;
 
     private final MetricResolver resolver;
 
-    @Inject
-    GaugeRegistrationInterceptor(MetricRegistry registry) {
-        this.registry = registry;
+    GaugeRegistrationInterceptor() {
         this.resolver = new MetricResolver();
     }
 
@@ -63,6 +61,7 @@ public class GaugeRegistrationInterceptor {
 
         BeanInfoAdapter<Class<?>> beanInfoAdapter = new CDIBeanInfoAdapter();
         MemberInfoAdapter<Member> memberInfoAdapter = new CDIMemberInfoAdapter();
+
         // Registers the gauges over the bean type hierarchy after the target is constructed as it is required for the gauge invocations
         do {
             // TODO: discover annotations declared on implemented interfaces
@@ -74,6 +73,9 @@ public class GaugeRegistrationInterceptor {
                     AnnotationInfo g = gauge.metricAnnotation();
                     Metadata metadata = MetricsMetadata.getMetadata(g, gauge.metricName(), g.unit(), g.description(),
                             g.displayName(), MetricType.GAUGE);
+
+                    registry = MetricRegistries.getOrCreate(g.scope());
+
                     registry.gauge(metadata,
                             context.getTarget(),
                             i -> (Number) invokeMethod(method, i),

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/interceptors/TimedInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/interceptors/TimedInterceptor.java
@@ -19,7 +19,7 @@ import org.eclipse.microprofile.metrics.MetricType;
 import org.eclipse.microprofile.metrics.Timer;
 import org.eclipse.microprofile.metrics.annotation.Timed;
 
-import io.smallrye.metrics.MetricRegistries;
+import io.smallrye.metrics.SharedMetricRegistries;
 import io.smallrye.metrics.SmallRyeMetricsMessages;
 import io.smallrye.metrics.elementdesc.adapter.cdi.CDIMemberInfoAdapter;
 import io.smallrye.metrics.legacyapi.LegacyMetricRegistryAdapter;
@@ -52,9 +52,9 @@ public class TimedInterceptor {
 
         Timed timedAnno = element.getAnnotation(Timed.class);
         if (timedAnno != null)
-            registry = MetricRegistries.getOrCreate(timedAnno.scope());
+            registry = SharedMetricRegistries.getOrCreate(timedAnno.scope());
         else
-            registry = MetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
+            registry = SharedMetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
 
         Set<MetricID> ids = ((LegacyMetricRegistryAdapter) registry).getMemberToMetricMappings()
                 .getTimers(new CDIMemberInfoAdapter<>().convert(element));

--- a/implementation/src/main/java/io/smallrye/metrics/setup/MPPrometheusMeterRegistry.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/MPPrometheusMeterRegistry.java
@@ -1,7 +1,5 @@
 package io.smallrye.metrics.setup;
 
-import org.eclipse.microprofile.metrics.MetricRegistry;
-
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 
@@ -13,15 +11,15 @@ import io.micrometer.prometheus.PrometheusMeterRegistry;
  */
 public class MPPrometheusMeterRegistry extends PrometheusMeterRegistry {
 
-    private final MetricRegistry.Type registryType;
+    private final String registryScope;
 
-    public MPPrometheusMeterRegistry(PrometheusConfig config, MetricRegistry.Type registryType) {
+    public MPPrometheusMeterRegistry(PrometheusConfig config, String registryScope) {
         super(config);
-        this.registryType = registryType;
+        this.registryScope = registryScope;
     }
 
-    public MetricRegistry.Type getType() {
-        return registryType;
+    public String getScope() {
+        return registryScope;
     }
 
 }

--- a/implementation/src/main/java/io/smallrye/metrics/setup/MetricsMetadata.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/MetricsMetadata.java
@@ -14,8 +14,8 @@ import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Timed;
 
 import io.micrometer.core.instrument.Tags;
-import io.smallrye.metrics.MetricRegistries;
 import io.smallrye.metrics.OriginAndMetadata;
+import io.smallrye.metrics.SharedMetricRegistries;
 import io.smallrye.metrics.elementdesc.AnnotationInfo;
 import io.smallrye.metrics.elementdesc.BeanInfo;
 import io.smallrye.metrics.elementdesc.MemberInfo;
@@ -35,7 +35,7 @@ public class MetricsMetadata {
         if (counted.isPresent()) {
             AnnotationInfo t = counted.metricAnnotation();
 
-            registry = MetricRegistries.getOrCreate(t.scope());
+            registry = SharedMetricRegistries.getOrCreate(t.scope());
 
             Metadata metadata = getMetadata(element, counted.metricName(), t.unit(), t.description(), t.displayName(),
                     MetricType.COUNTER);
@@ -71,7 +71,7 @@ public class MetricsMetadata {
         if (timed.isPresent()) {
             AnnotationInfo t = timed.metricAnnotation();
 
-            registry = MetricRegistries.getOrCreate(t.scope());
+            registry = SharedMetricRegistries.getOrCreate(t.scope());
 
             Metadata metadata = getMetadata(element, timed.metricName(), t.unit(), t.description(), t.displayName(),
                     MetricType.TIMER);

--- a/implementation/src/test/java/io/smallrye/metrics/MetricRegistryThreadSafetyTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/MetricRegistryThreadSafetyTest.java
@@ -40,7 +40,7 @@ import org.junit.Test;
 
 public class MetricRegistryThreadSafetyTest {
 
-    private final MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
+    private final MetricRegistry registry = SharedMetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
 
     @After
     public void cleanup() {

--- a/implementation/src/test/java/io/smallrye/metrics/MetricRegistryThreadSafetyTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/MetricRegistryThreadSafetyTest.java
@@ -40,7 +40,7 @@ import org.junit.Test;
 
 public class MetricRegistryThreadSafetyTest {
 
-    private final MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.Type.APPLICATION);
+    private final MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
 
     @After
     public void cleanup() {

--- a/implementation/src/test/java/io/smallrye/metrics/exporters/MpMetricsCompatibility_Programmatic_PrometheusTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/exporters/MpMetricsCompatibility_Programmatic_PrometheusTest.java
@@ -38,7 +38,7 @@ import org.junit.Test;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
-import io.smallrye.metrics.MetricRegistries;
+import io.smallrye.metrics.SharedMetricRegistries;
 
 /**
  * Verifies functionality of the legacy MetricRegistry adapter - puts a Prometheus MeterRegistry behind it,
@@ -68,12 +68,12 @@ public class MpMetricsCompatibility_Programmatic_PrometheusTest {
 
     @After
     public void cleanupApplicationMetrics() {
-        MetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE).removeMatching(MetricFilter.ALL);
+        SharedMetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE).removeMatching(MetricFilter.ALL);
     }
 
     @Test
     public void exportCounters() {
-        MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
+        MetricRegistry registry = SharedMetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
 
         Metadata metadata = Metadata
                 .builder()

--- a/implementation/src/test/java/io/smallrye/metrics/exporters/MpMetricsCompatibility_Programmatic_PrometheusTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/exporters/MpMetricsCompatibility_Programmatic_PrometheusTest.java
@@ -68,12 +68,12 @@ public class MpMetricsCompatibility_Programmatic_PrometheusTest {
 
     @After
     public void cleanupApplicationMetrics() {
-        MetricRegistries.getOrCreate(MetricRegistry.Type.APPLICATION).removeMatching(MetricFilter.ALL);
+        MetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE).removeMatching(MetricFilter.ALL);
     }
 
     @Test
     public void exportCounters() {
-        MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.Type.APPLICATION);
+        MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
 
         Metadata metadata = Metadata
                 .builder()

--- a/implementation/src/test/java/io/smallrye/metrics/registration/MetadataMismatchTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/registration/MetadataMismatchTest.java
@@ -36,7 +36,7 @@ import io.smallrye.metrics.MetricRegistries;
 
 public class MetadataMismatchTest {
 
-    private MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.Type.APPLICATION);
+    private MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
 
     @After
     public void cleanupApplicationMetrics() {

--- a/implementation/src/test/java/io/smallrye/metrics/registration/MetadataMismatchTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/registration/MetadataMismatchTest.java
@@ -32,11 +32,11 @@ import org.junit.After;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import io.smallrye.metrics.MetricRegistries;
+import io.smallrye.metrics.SharedMetricRegistries;
 
 public class MetadataMismatchTest {
 
-    private MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
+    private MetricRegistry registry = SharedMetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
 
     @After
     public void cleanupApplicationMetrics() {

--- a/implementation/src/test/java/io/smallrye/metrics/registration/MetricTypeMismatchTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/registration/MetricTypeMismatchTest.java
@@ -26,11 +26,11 @@ import org.eclipse.microprofile.metrics.MetricType;
 import org.junit.After;
 import org.junit.Test;
 
-import io.smallrye.metrics.MetricRegistries;
+import io.smallrye.metrics.SharedMetricRegistries;
 
 public class MetricTypeMismatchTest {
 
-    private MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
+    private MetricRegistry registry = SharedMetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
 
     @After
     public void cleanupApplicationMetrics() {

--- a/implementation/src/test/java/io/smallrye/metrics/registration/MetricTypeMismatchTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/registration/MetricTypeMismatchTest.java
@@ -30,7 +30,7 @@ import io.smallrye.metrics.MetricRegistries;
 
 public class MetricTypeMismatchTest {
 
-    private MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.Type.APPLICATION);
+    private MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
 
     @After
     public void cleanupApplicationMetrics() {

--- a/implementation/src/test/java/io/smallrye/metrics/registration/ReusabilityByDefaultTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/registration/ReusabilityByDefaultTest.java
@@ -39,7 +39,7 @@ import io.smallrye.metrics.MetricRegistries;
  */
 public class ReusabilityByDefaultTest {
 
-    private final MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.Type.APPLICATION);
+    private final MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
 
     @After
     public void removeMetrics() {
@@ -73,14 +73,6 @@ public class ReusabilityByDefaultTest {
         assertEquals(2, registry.histogram("myhistogram").getCount());
     }
 
-    //    @Test
-    //    public void testSimpleTimer() {
-    //        Metadata metadata = Metadata.builder().withName("mysimpletimer").build();
-    //        registry.simpleTimer(metadata).update(Duration.ofNanos(5));
-    //        registry.simpleTimer(metadata).update(Duration.ofNanos(7));
-    //        assertEquals(2, registry.simpleTimer("mysimpletimer").getCount());
-    //    }
-
     @Test
     public void testTimer() {
         Metadata metadata = Metadata.builder().withName("mytimer").build();
@@ -88,26 +80,5 @@ public class ReusabilityByDefaultTest {
         registry.timer(metadata).update(Duration.ofNanos(7));
         assertEquals(2, registry.timer("mytimer").getCount());
     }
-
-    //    @Test
-    //    public void testMeter() {
-    //        Metadata metadata = Metadata.builder().withName("mymeter").build();
-    //        registry.meter(metadata).mark(100);
-    //        registry.meter(metadata).mark(100);
-    //        assertEquals(200, registry.meter("mymeter").getCount());
-    //    }
-    //
-    //    @Test
-    //    public void testConcurrentGauge() {
-    //        Metadata metadata = Metadata.builder().withName("mycgauge").withUnit(MetricUnits.SECONDS).build();
-    //        try {
-    //            registry.concurrentGauge(metadata).inc();
-    //            registry.concurrentGauge(metadata).inc();
-    //            assertEquals(2, registry.concurrentGauge("mycgauge").getCount());
-    //        } finally {
-    //            registry.concurrentGauge(metadata).dec();
-    //            registry.concurrentGauge(metadata).dec();
-    //        }
-    //    }
 
 }

--- a/implementation/src/test/java/io/smallrye/metrics/registration/ReusabilityByDefaultTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/registration/ReusabilityByDefaultTest.java
@@ -32,14 +32,14 @@ import org.junit.Test;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import io.smallrye.metrics.MetricRegistries;
+import io.smallrye.metrics.SharedMetricRegistries;
 
 /**
  * Verify that programmatically created metrics can be reused.
  */
 public class ReusabilityByDefaultTest {
 
-    private final MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
+    private final MetricRegistry registry = SharedMetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
 
     @After
     public void removeMetrics() {


### PR DESCRIPTION
Related to: https://github.com/eclipse/microprofile-metrics/pull/712a
Depends on :

FIRST: https://github.com/smallrye/smallrye-metrics/pull/513
SECOND: https://github.com/smallrye/smallrye-metrics/pull/517
(Current PR contains the commits of above 2 )

Relevant commit is (or whatever the last commit is ):https://github.com/smallrye/smallrye-metrics/pull/521/commits/4fdf22ffea78713e8971b4d84e9d1d0d8ede5098

Implement getSnapShot() for `Histogram` and `Timer`
Add `SnapshotAdapter` which implements the new changes in MP Metrics 5.0 