### PR TITLE
Force create the base registry

### DIFF
--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/LegacyMetricsExtension.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/LegacyMetricsExtension.java
@@ -168,6 +168,9 @@ public class LegacyMetricsExtension implements Extension {
     }
 
     void registerMetrics(@Observes AfterDeploymentValidation adv, BeanManager manager) {
+        // create the "base" registry, this will allow the base metrics to be added
+        // should this be done here, or should it be called by servers consuming this library?
+        MetricRegistry baseRegistry = SharedMetricRegistries.getOrCreate(MetricRegistry.BASE_SCOPE);
 
         // Produce and register custom metrics
         MetricRegistry registry = MetricRegistries.getOrCreate(MetricRegistry.Type.APPLICATION);


### PR DESCRIPTION
This PR forces the `base` scope to be created, which in turn adds the base JVM metrics.