### PR TITLE
Fix issue where async listener is not registered for onComplete/onTim…

### DIFF
--- a/implementation/src/main/java/io/smallrye/metrics/jaxrs/JaxRsMetricsServletFilter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/jaxrs/JaxRsMetricsServletFilter.java
@@ -64,6 +64,16 @@ public class JaxRsMetricsServletFilter implements Filter {
 
                         @Override
                         public void onStartAsync(AsyncEvent event) {
+                            // from the Servlet specification for startAsync():
+                            // "This method clears the list of AsyncListener instances (if any)
+                            // that were registered with the AsyncContext returned by the
+                            // previous call to one of the startAsync methods, after calling
+                            // each AsyncListener at its onStartAsync method."
+                            //
+                            // if onStartAsync is call, its likely we need to register this
+                            // listener again in order for the other callbacks to be called.
+
+                            event.getAsyncContext().addListener(this);
                         }
                     });
                 }


### PR DESCRIPTION
…eout/onError callbacks

The startAsync() method (which causes the onStartAsync() method to be called on an AsyncListener) _removes_ the listeners on the AsyncContext after calling them.

This PR simply adds the listener again, so SmallRye is called when async calls complete or error so the relevant metrics are still updated for REST resources that are asynchronous.