### PR TITLE
Remove Java 8 from build, MP Config no longer supports Java 8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,3 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: io.smallrye.config:smallrye-config
-    versions:
-    - 2.1.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,10 @@ name: SmallRye Build
 
 on:
   push:
-    branches-ignore:
-      - 'dependabot/**'
+    branches:
+      - main
+      - jakarta
+      - micrometer
     paths-ignore:
       - '.gitignore'
       - 'CODEOWNERS'
@@ -23,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 11, 17]
+        java: [11, 17]
     name: build with jdk ${{matrix.java}}
 
     steps:

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 :microprofile-metrics: https://github.com/eclipse/microprofile-metrics/
-:ci: https://github.com/smallrye/smallrye-config/actions?query=workflow%3A%22SmallRye+Build%22
-:sonar: https://sonarcloud.io/dashboard?id=smallrye_smallrye-config
+:ci: https://github.com/smallrye/smallrye-metrics/actions?query=workflow%3A%22SmallRye+Build%22
+:sonar: https://sonarcloud.io/dashboard?id=smallrye_smallrye-metrics
 
 image:https://github.com/smallrye/smallrye-metrics/workflows/SmallRye%20Build/badge.svg?branch=main[link={ci}]
 image:https://sonarcloud.io/api/project_badges/measure?project=smallrye_smallrye-metrics&metric=alert_status["Quality Gate Status", link={sonar}]


### PR DESCRIPTION
Similar to : 
https://github.com/smallrye/smallrye-metrics/commit/e40d844d6056597459fedacd7f917fc704e89ce3

Some of the changes were already made previously.

Skipped the publishing of TCK change.