### PR TITLE
Make certain classes more proxy-able

### DIFF
--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/LegacyMetricRegistryAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/LegacyMetricRegistryAdapter.java
@@ -61,7 +61,7 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
         return registry;
     }
 
-    protected void addNameToApplicationMap(MetricID metricID) {
+    public void addNameToApplicationMap(MetricID metricID) {
         String appName = appNameResolver.getApplicationName();
         addNameToApplicationMap(metricID, appName);
     }

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/interceptors/CountedInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/interceptors/CountedInterceptor.java
@@ -62,7 +62,9 @@ public class CountedInterceptor {
                 .map(metricID -> {
                     Counter metric = registry.getCounters().get(metricID);
                     if (metric == null) {
-                        throw SmallRyeMetricsMessages.msg.noMetricFoundInRegistry(metricID);
+                        throw new IllegalStateException(
+                                "No metric with ID " + metricID + " found in registry");
+
                     }
                     return metric;
                 })

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/interceptors/SeMetricName.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/interceptors/SeMetricName.java
@@ -16,11 +16,11 @@ import org.eclipse.microprofile.metrics.annotation.Metric;
 import io.smallrye.metrics.SmallRyeMetricsMessages;
 
 @Vetoed
-/* package-private */ class SeMetricName implements MetricName {
+public class SeMetricName implements MetricName {
 
     private final Set<MetricsParameter> parameters;
 
-    SeMetricName(Set<MetricsParameter> parameters) {
+    public SeMetricName(Set<MetricsParameter> parameters) {
         this.parameters = parameters;
     }
 

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/interceptors/TimedInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/interceptors/TimedInterceptor.java
@@ -65,7 +65,8 @@ public class TimedInterceptor {
                 .map(metricID -> {
                     Timer metric = registry.getTimers().get(metricID);
                     if (metric == null) {
-                        throw SmallRyeMetricsMessages.msg.noMetricFoundInRegistry(metricID);
+                        throw new IllegalStateException(
+                                "No metric with ID " + metricID + " found in registry");
                     }
                     return metric;
                 })


### PR DESCRIPTION
For the `micrometer` branch.

A few things:
- Make methods public to help with implementations that need to proxy the methods othe clsas.
- Directly instantiate SeMetricName in MetricProducer, instead of using CDI.
^Was initially intending to completely remove the `MetricNameFactory` and merge `SeMetricName` and the `MetricName` interface together as one (i.e. result in a `MetricName` **class** in the end, but noticed that there may have been intentions to provide support for an _external_ CDI strategies? (Worth dicussing) See :https://github.com/smallrye/smallrye-metrics/blob/main/implementation/src/main/java/io/smallrye/metrics/interceptors/MetricName.java#L27
- Not use Jboss logging to throw ISE in counted and timed interceptors.
^Need to finalize on a logging solution.