### PR TITLE
Fix incorrectly reported heap metrics

### DIFF
--- a/implementation/src/main/java/io/smallrye/metrics/base/LegacyBaseMetrics.java
+++ b/implementation/src/main/java/io/smallrye/metrics/base/LegacyBaseMetrics.java
@@ -188,14 +188,16 @@ public class LegacyBaseMetrics implements MeterBinder {
     }
 
     private void baseMemoryMetrics(MeterRegistry registry) {
-        MemoryMXBean memoryMXBean = ManagementFactory.getMemoryMXBean();
+        final MemoryMXBean memoryMXBean = ManagementFactory.getMemoryMXBean();
+
         Gauge.builder(MEMORY_COMMITTED_HEAP,
-                memoryMXBean.getHeapMemoryUsage()::getCommitted)
+                () -> memoryMXBean.getHeapMemoryUsage().getCommitted())
                 .description("Displays the amount of memory in bytes that is committed for the Java virtual machine to use. " +
                         "This amount of memory is guaranteed for the Java virtual machine to use.")
                 .baseUnit(BaseUnits.BYTES).tag(LegacyMetricRegistryAdapter.MP_SCOPE_TAG, "base").register(registry);
+
         Gauge.builder(MEMORY_MAX_HEAP,
-                memoryMXBean.getHeapMemoryUsage()::getMax)
+                () -> memoryMXBean.getHeapMemoryUsage().getMax())
                 .description("Displays the maximum amount of heap memory in bytes that can be used for memory management. "
                         +
                         "This attribute displays -1 if the maximum heap memory size is undefined. This amount of memory is not "
@@ -205,8 +207,10 @@ public class LegacyBaseMetrics implements MeterBinder {
                         "The Java virtual machine may fail to allocate memory even if the amount of used memory does " +
                         "not exceed this maximum size.")
                 .baseUnit(BaseUnits.BYTES).tag(LegacyMetricRegistryAdapter.MP_SCOPE_TAG, "base").register(registry);
+
         Gauge.builder(MEMORY_USED_HEAP,
-                memoryMXBean.getHeapMemoryUsage()::getUsed).description("Displays the amount of used heap memory in bytes.")
+                () -> memoryMXBean.getHeapMemoryUsage().getUsed())
+                .description("Displays the amount of used heap memory in bytes.")
                 .baseUnit(BaseUnits.BYTES).tag(LegacyMetricRegistryAdapter.MP_SCOPE_TAG, "base").register(registry);
     }
 }


### PR DESCRIPTION
The use of `memoryMXBean.getHeapMemoryUsage()::getUsed` causes `getUsed()` to be called on an old memory usage object. The effect here is that the 1st value scraped would be reported indefinitely.

Using `() -> memoryMXBean.getHeapMemoryUsage().getUsed()` gets a new memory usage object from the MBean each time.