### PR TITLE
Address code improvements from issue:

### DIFF
--- a/implementation/src/main/java/io/smallrye/metrics/SharedMetricRegistries.java
+++ b/implementation/src/main/java/io/smallrye/metrics/SharedMetricRegistries.java
@@ -212,7 +212,7 @@ public class SharedMetricRegistries {
             } catch (ClassNotFoundException | SecurityException | IllegalArgumentException | IllegalAccessException
                     | NoSuchMethodException | InstantiationException | InvocationTargetException e) {
                 LOGGER.logp(Level.SEVERE, CLASS_NAME, METHOD_NAME,
-                        "Encountered exception while reflectively loading Micrometer Prometheus classes: {0}", e);
+                        "Encountered exception while reflectively loading Micrometer Prometheus classes: ", e);
                 /*
                  * Default to simple meter registry otherwise. No Need to create a "MPSimpleMeterRegisty with scope
                  * field as scope was only used for the PrometheusExporter

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/HistogramAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/HistogramAdapter.java
@@ -11,7 +11,6 @@ import org.eclipse.microprofile.metrics.Snapshot;
 
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Meter;
-import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tag;
 

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/HistogramAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/HistogramAdapter.java
@@ -22,12 +22,6 @@ class HistogramAdapter implements Histogram, MeterHolder {
 
     private final static int PRECISION;
 
-    final MeterRegistry registry;
-
-    HistogramAdapter(MeterRegistry registry) {
-        this.registry = registry;
-    }
-
     /*
      * Increasing the percentile precision for histograms will consume more memory.
      * This setting is "3" by default, and provided to adjust the precision to

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/HistogramAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/HistogramAdapter.java
@@ -22,6 +22,12 @@ class HistogramAdapter implements Histogram, MeterHolder {
 
     private final static int PRECISION;
 
+    final MeterRegistry registry;
+
+    HistogramAdapter(MeterRegistry registry) {
+        this.registry = registry;
+    }
+
     /*
      * Increasing the percentile precision for histograms will consume more memory.
      * This setting is "3" by default, and provided to adjust the precision to
@@ -38,7 +44,7 @@ class HistogramAdapter implements Histogram, MeterHolder {
 
     DistributionSummary globalCompositeSummary;
 
-    public HistogramAdapter register(MpMetadata metadata, MetricDescriptor metricInfo, MeterRegistry registry, String scope,
+    public HistogramAdapter register(MpMetadata metadata, MetricDescriptor metricInfo, String scope,
             Tag... globalTags) {
 
         if (globalCompositeSummary == null || metadata.cleanDirtyMetadata()) {

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/LegacyMetricRegistryAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/LegacyMetricRegistryAdapter.java
@@ -95,6 +95,14 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
     }
 
     /**
+     * Associates a metric's MetricID to a specific application if an application name can be resolved.
+     */
+    public void addNameToApplicationMap(MetricID MetricID) {
+        if (isAppnameResolverPresent)
+            addNameToApplicationMap(MetricID, appNameResolver.getApplicationName());
+    }
+
+    /**
      * Adds the MetricID to an application map given the application name.
      * This map is not a complete list of metrics owned by an application,
      * produced metrics are managed in the MetricsExtension
@@ -151,8 +159,20 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
     }
 
     public LegacyMetricRegistryAdapter(String scope, MeterRegistry registry, ApplicationNameResolver appNameResolver) {
-        this.appNameResolver = (appNameResolver == null) ? ApplicationNameResolver.DEFAULT : appNameResolver;
-        isAppnameResolverPresent = (this.appNameResolver.equals(ApplicationNameResolver.DEFAULT)) ? false : true;
+
+        /*
+         * Note: if ApplicationNameResolver is passed through as Java Reflection Proxy object,
+         * can only be checked if its is "null".
+         * Trying any other operations would lead to an Exception (i.e. equals())
+         */
+        if (appNameResolver == null) {
+            this.appNameResolver = ApplicationNameResolver.DEFAULT;
+            isAppnameResolverPresent = false;
+        } else {
+            this.appNameResolver = appNameResolver;
+            isAppnameResolverPresent = true;
+        }
+
         this.scope = scope;
         this.registry = registry;
 

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/LegacyMetricRegistryAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/LegacyMetricRegistryAdapter.java
@@ -87,12 +87,11 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
     }
 
     /**
-     * This method should not be called when {@link #isAppNameResolverPresent}
-     * is false as this method does nothing in that case.
+     * Associates a metric's MetricID to a specific application if an application name can be resolved.
      */
-    public void addNameToApplicationMap(MetricID metricID) {
-        String appName = appNameResolver.getApplicationName();
-        addNameToApplicationMap(metricID, appName);
+    public void addNameToApplicationMap(MetricDescriptor metricDescriptor) {
+        if (isAppnameResolverPresent)
+            addNameToApplicationMap(metricDescriptor.toMetricID(), appNameResolver.getApplicationName());
     }
 
     /**
@@ -427,8 +426,7 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
 
         CounterAdapter result = checkCast(CounterAdapter.class, metadata,
                 constructedMeters.computeIfAbsent(id, k -> new CounterAdapter()));
-        if (isAppnameResolverPresent)
-            addNameToApplicationMap(id.toMetricID());
+        addNameToApplicationMap(id);
 
         return result.register(metadata, id, registry, scope, resolveMPConfigGlobalTagsByServer());
     }
@@ -463,8 +461,7 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
 
         FunctionCounterAdapter<T> result = checkCast(FunctionCounterAdapter.class, metadata,
                 constructedMeters.computeIfAbsent(id, k -> new FunctionCounterAdapter(obj, func)));
-        if (isAppnameResolverPresent)
-            addNameToApplicationMap(id.toMetricID());
+        addNameToApplicationMap(id);
         return result.register(metadata, id, registry, scope, resolveMPConfigGlobalTagsByServer());
     }
 
@@ -524,8 +521,7 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
         validateTagNamesMatch(id);
         GaugeAdapter.DoubleFunctionGauge<T> result = checkCast(GaugeAdapter.DoubleFunctionGauge.class, metadata,
                 constructedMeters.computeIfAbsent(id, k -> new GaugeAdapter.DoubleFunctionGauge<>(obj, f)));
-        if (isAppnameResolverPresent)
-            addNameToApplicationMap(id.toMetricID());
+        addNameToApplicationMap(id);
         return result.register(metadata, id, registry, scope, resolveMPConfigGlobalTagsByServer());
     }
 
@@ -534,8 +530,7 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
         validateTagNamesMatch(id);
         GaugeAdapter.FunctionGauge<T, R> result = checkCast(GaugeAdapter.FunctionGauge.class, metadata,
                 constructedMeters.computeIfAbsent(id, k -> new GaugeAdapter.FunctionGauge<>(obj, f)));
-        if (isAppnameResolverPresent)
-            addNameToApplicationMap(id.toMetricID());
+        addNameToApplicationMap(id);
         return result.register(metadata, id, registry, scope, resolveMPConfigGlobalTagsByServer());
     }
 
@@ -583,8 +578,7 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
         validateTagNamesMatch(id);
         GaugeAdapter<T> result = checkCast(GaugeAdapter.NumberSupplierGauge.class, metadata,
                 constructedMeters.computeIfAbsent(id, k -> new GaugeAdapter.NumberSupplierGauge<T>(f)));
-        if (isAppnameResolverPresent)
-            addNameToApplicationMap(id.toMetricID());
+        addNameToApplicationMap(id);
         return result.register(metadata, id, registry, scope, resolveMPConfigGlobalTagsByServer());
     }
 
@@ -650,8 +644,7 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
         validateTagNamesMatch(id);
         HistogramAdapter result = checkCast(HistogramAdapter.class, metadata,
                 constructedMeters.computeIfAbsent(id, k -> new HistogramAdapter()));
-        if (isAppnameResolverPresent)
-            addNameToApplicationMap(id.toMetricID());
+        addNameToApplicationMap(id);
         return result.register(metadata, id, scope, resolveMPConfigGlobalTagsByServer());
     }
 
@@ -704,8 +697,7 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
         validateTagNamesMatch(id);
         TimerAdapter result = checkCast(TimerAdapter.class, metadata,
                 constructedMeters.computeIfAbsent(id, k -> new TimerAdapter(registry)));
-        if (isAppnameResolverPresent)
-            addNameToApplicationMap(id.toMetricID());
+        addNameToApplicationMap(id);
         return result.register(metadata, id, scope, resolveMPConfigGlobalTagsByServer());
     }
 

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/LegacyMetricRegistryAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/LegacyMetricRegistryAdapter.java
@@ -87,8 +87,8 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
     }
 
     /**
-     * Calls to this method should check {@link #isAppNameResolverPresent}
-     * to avoid overhead of having to convert {@link MetricDescriptor} to {@link MetricID}
+     * This method should not be called when {@link #isAppNameResolverPresent}
+     * is false as this method does nothing in that case.
      */
     public void addNameToApplicationMap(MetricID metricID) {
         String appName = appNameResolver.getApplicationName();
@@ -153,7 +153,7 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
 
     public LegacyMetricRegistryAdapter(String scope, MeterRegistry registry, ApplicationNameResolver appNameResolver) {
         this.appNameResolver = (appNameResolver == null) ? ApplicationNameResolver.DEFAULT : appNameResolver;
-        isAppnameResolverPresent = (this.appNameResolver == null) ? false : true;
+        isAppnameResolverPresent = (this.appNameResolver.equals(ApplicationNameResolver.DEFAULT)) ? false : true;
         this.scope = scope;
         this.registry = registry;
 
@@ -649,7 +649,7 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
     HistogramAdapter internalHistogram(MpMetadata metadata, MetricDescriptor id) {
         validateTagNamesMatch(id);
         HistogramAdapter result = checkCast(HistogramAdapter.class, metadata,
-                constructedMeters.computeIfAbsent(id, k -> new HistogramAdapter(registry)));
+                constructedMeters.computeIfAbsent(id, k -> new HistogramAdapter()));
         if (isAppnameResolverPresent)
             addNameToApplicationMap(id.toMetricID());
         return result.register(metadata, id, scope, resolveMPConfigGlobalTagsByServer());


### PR DESCRIPTION
- boolean for presence of AppNameResolver, use before addNameToApplicationMap to reduce MetricDescriptor to MetricID conversion
- create HashMap in combineApplicationTagsWithMPConfigAppNameTag after MP Config property  null check
- removed isSorted parameter from above mentioned method
- Included ctor for HistogramAdapter with MeterRegistry param for consistency

other:
- Cleaned up commented code + sys out
- Removed useless object substitute in log statement in SharedMetricRegistries

fixes #562