### PR TITLE
Support Mp Metrics 5.1 MP Config properties for Histogram and Timer metrics

### DIFF
--- a/implementation/src/main/java/io/smallrye/metrics/SharedMetricRegistries.java
+++ b/implementation/src/main/java/io/smallrye/metrics/SharedMetricRegistries.java
@@ -134,6 +134,10 @@ public class SharedMetricRegistries {
         appNameResolver = anr;
     }
 
+    public static ApplicationNameResolver getAppNameResolver() {
+        return appNameResolver;
+    }
+
     public static Set<String> getRegistryScopeNames() {
         //return copy of 'registries' key-set containing scope names
         return new HashSet<String>(registries.keySet());

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/HistogramAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/HistogramAdapter.java
@@ -4,15 +4,23 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Stream;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.metrics.Histogram;
 import org.eclipse.microprofile.metrics.Snapshot;
 
 import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.DistributionSummary.Builder;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tag;
+import io.smallrye.metrics.setup.config.DefaulBucketConfiguration;
+import io.smallrye.metrics.setup.config.HistogramBucketConfiguration;
+import io.smallrye.metrics.setup.config.HistogramBucketMaxConfiguration;
+import io.smallrye.metrics.setup.config.HistogramBucketMinConfiguration;
+import io.smallrye.metrics.setup.config.MetricPercentileConfiguration;
+import io.smallrye.metrics.setup.config.MetricsConfigurationManager;
 
 class HistogramAdapter implements Histogram, MeterHolder {
 
@@ -22,13 +30,12 @@ class HistogramAdapter implements Histogram, MeterHolder {
     private final static int PRECISION;
 
     /*
-     * Increasing the percentile precision for histograms will consume more memory.
-     * This setting is "3" by default, and provided to adjust the precision to
-     * your needs.
+     * Increasing the percentile precision for histograms will consume more memory. This setting is "3"
+     * by default, and provided to adjust the precision to your needs.
      */
     static {
-        PRECISION = ConfigProvider.getConfig().getOptionalValue("mp.metrics.smallrye.histogram.precision", Integer.class)
-                .orElse(3);
+        PRECISION = ConfigProvider.getConfig()
+                .getOptionalValue("mp.metrics.smallrye.histogram.precision", Integer.class).orElse(3);
         if (LOGGER.isLoggable(Level.FINE)) {
             LOGGER.logp(Level.FINE, CLASS_NAME, null,
                     "Resolved MicroProfile Config value for mp.metrics.smallrye.histogram.precision as \"{0}\"", PRECISION);
@@ -41,6 +48,15 @@ class HistogramAdapter implements Histogram, MeterHolder {
             Tag... globalTags) {
 
         if (globalCompositeSummary == null || metadata.cleanDirtyMetadata()) {
+
+            MetricPercentileConfiguration percentilesConfig = MetricsConfigurationManager.getInstance()
+                    .getPercentilesConfiguration(metadata.getName());
+
+            HistogramBucketConfiguration bucketsConfig = MetricsConfigurationManager.getInstance()
+                    .getHistogrmBucketConfiguration(metadata.getName());
+
+            DefaulBucketConfiguration defaultBucketConfig = MetricsConfigurationManager.getInstance()
+                    .getDefaultBucketConfiguration(metadata.getName());
 
             Set<Tag> tagsSet = new HashSet<Tag>();
             for (Tag t : metricInfo.tags()) {
@@ -55,13 +71,48 @@ class HistogramAdapter implements Histogram, MeterHolder {
 
             tagsSet.add(Tag.of(LegacyMetricRegistryAdapter.MP_SCOPE_TAG, scope));
 
-            globalCompositeSummary = DistributionSummary.builder(metricInfo.name())
-                    .description(metadata.getDescription())
-                    .baseUnit(metadata.getUnit())
-                    .tags(tagsSet)
-                    .publishPercentiles(0.5, 0.75, 0.95, 0.98, 0.99, 0.999)
-                    .percentilePrecision(PRECISION)
-                    .register(Metrics.globalRegistry);
+            Builder builder = DistributionSummary.builder(metricInfo.name()).description(metadata.getDescription())
+                    .baseUnit(metadata.getUnit()).tags(tagsSet).percentilePrecision(PRECISION);
+
+            if (percentilesConfig != null && percentilesConfig.getValues() != null
+                    && percentilesConfig.getValues().length > 0) {
+                double[] vals = Stream.of(percentilesConfig.getValues()).mapToDouble(Double::doubleValue).toArray();
+                builder = builder.publishPercentiles(vals);
+            } else if (percentilesConfig != null && percentilesConfig.getValues() == null
+                    && percentilesConfig.isDisabled() == true) {
+                //do nothing - percentiles were disabled
+            } else {
+                builder = builder.publishPercentiles(0.5, 0.75, 0.95, 0.98, 0.99, 0.999);
+            }
+
+            if (bucketsConfig != null && bucketsConfig.getValues().length > 0) {
+                double[] vals = Stream.of(bucketsConfig.getValues()).mapToDouble(Double::doubleValue).toArray();
+                builder = builder.serviceLevelObjectives(vals);
+            }
+
+            if (defaultBucketConfig != null && defaultBucketConfig.getIsEnabled() == true) {
+
+                builder = builder.publishPercentileHistogram(defaultBucketConfig.getIsEnabled());
+
+                HistogramBucketMaxConfiguration defaultBucketMaxConfig = MetricsConfigurationManager.getInstance()
+                        .getDefaultHistogramMaxBucketConfiguration(metadata.getName());
+
+                if (defaultBucketMaxConfig != null && defaultBucketMaxConfig.getValue() != null
+                        && defaultBucketMaxConfig.getValue() != Double.NaN) {
+                    builder = builder.maximumExpectedValue(defaultBucketMaxConfig.getValue());
+                }
+
+                HistogramBucketMinConfiguration defaultBucketMinConfig = MetricsConfigurationManager.getInstance()
+                        .getDefaultHistogramMinBucketConfiguration(metadata.getName());
+
+                if (defaultBucketMinConfig != null && defaultBucketMinConfig.getValue() != null
+                        && defaultBucketMinConfig.getValue() != Double.NaN) {
+                    builder = builder.minimumExpectedValue(defaultBucketMinConfig.getValue());
+                }
+            }
+
+            globalCompositeSummary = builder.register(Metrics.globalRegistry);
+
         }
         return this;
     }

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/HistogramAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/HistogramAdapter.java
@@ -15,7 +15,7 @@ import io.micrometer.core.instrument.DistributionSummary.Builder;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tag;
-import io.smallrye.metrics.setup.config.DefaulBucketConfiguration;
+import io.smallrye.metrics.setup.config.DefaultBucketConfiguration;
 import io.smallrye.metrics.setup.config.HistogramBucketConfiguration;
 import io.smallrye.metrics.setup.config.HistogramBucketMaxConfiguration;
 import io.smallrye.metrics.setup.config.HistogramBucketMinConfiguration;
@@ -53,9 +53,9 @@ class HistogramAdapter implements Histogram, MeterHolder {
                     .getPercentilesConfiguration(metadata.getName());
 
             HistogramBucketConfiguration bucketsConfig = MetricsConfigurationManager.getInstance()
-                    .getHistogrmBucketConfiguration(metadata.getName());
+                    .getHistogramBucketConfiguration(metadata.getName());
 
-            DefaulBucketConfiguration defaultBucketConfig = MetricsConfigurationManager.getInstance()
+            DefaultBucketConfiguration defaultBucketConfig = MetricsConfigurationManager.getInstance()
                     .getDefaultBucketConfiguration(metadata.getName());
 
             Set<Tag> tagsSet = new HashSet<Tag>();
@@ -79,7 +79,7 @@ class HistogramAdapter implements Histogram, MeterHolder {
                 double[] vals = Stream.of(percentilesConfig.getValues()).mapToDouble(Double::doubleValue).toArray();
                 builder = builder.publishPercentiles(vals);
             } else if (percentilesConfig != null && percentilesConfig.getValues() == null
-                    && percentilesConfig.isDisabled() == true) {
+                    && percentilesConfig.isDisabled()) {
                 //do nothing - percentiles were disabled
             } else {
                 builder = builder.publishPercentiles(0.5, 0.75, 0.95, 0.98, 0.99, 0.999);
@@ -90,9 +90,9 @@ class HistogramAdapter implements Histogram, MeterHolder {
                 builder = builder.serviceLevelObjectives(vals);
             }
 
-            if (defaultBucketConfig != null && defaultBucketConfig.getIsEnabled() == true) {
+            if (defaultBucketConfig != null && defaultBucketConfig.isEnabled()) {
 
-                builder = builder.publishPercentileHistogram(defaultBucketConfig.getIsEnabled());
+                builder = builder.publishPercentileHistogram(defaultBucketConfig.isEnabled());
 
                 HistogramBucketMaxConfiguration defaultBucketMaxConfig = MetricsConfigurationManager.getInstance()
                         .getDefaultHistogramMaxBucketConfiguration(metadata.getName());

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/SnapshotAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/SnapshotAdapter.java
@@ -4,7 +4,9 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 
 import org.eclipse.microprofile.metrics.Snapshot;
+import org.eclipse.microprofile.metrics.Snapshot.PercentileValue;
 
+import io.micrometer.core.instrument.distribution.CountAtBucket;
 import io.micrometer.core.instrument.distribution.HistogramSnapshot;
 import io.micrometer.core.instrument.distribution.ValueAtPercentile;
 
@@ -37,7 +39,8 @@ public class SnapshotAdapter extends Snapshot {
         PercentileValue[] percentileValues = new PercentileValue[valueAtPercentiles.length];
 
         for (int i = 0; i < valueAtPercentiles.length; i++) {
-            percentileValues[i] = new PercentileValue(valueAtPercentiles[i].percentile(), valueAtPercentiles[i].value());
+            percentileValues[i] = new PercentileValue(valueAtPercentiles[i].percentile(),
+                    valueAtPercentiles[i].value());
         }
 
         return percentileValues;
@@ -47,6 +50,18 @@ public class SnapshotAdapter extends Snapshot {
     public void dump(OutputStream output) {
         histogramSnapshot.outputSummary(new PrintStream(output), 1);
 
+    }
+
+    @Override
+    public HistogramBucket[] bucketValues() {
+        CountAtBucket[] countAtBucket = histogramSnapshot.histogramCounts();
+        HistogramBucket[] histogramBuckets = new HistogramBucket[countAtBucket.length];
+
+        for (int i = 0; i < countAtBucket.length; i++) {
+            histogramBuckets[i] = new HistogramBucket(countAtBucket[i].bucket(), (long) countAtBucket[i].count());
+        }
+
+        return histogramBuckets;
     }
 
 }

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/TimerAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/TimerAdapter.java
@@ -18,7 +18,7 @@ import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.Timer.Builder;
-import io.smallrye.metrics.setup.config.DefaulBucketConfiguration;
+import io.smallrye.metrics.setup.config.DefaultBucketConfiguration;
 import io.smallrye.metrics.setup.config.MetricPercentileConfiguration;
 import io.smallrye.metrics.setup.config.MetricsConfigurationManager;
 import io.smallrye.metrics.setup.config.TimerBucketConfiguration;
@@ -63,7 +63,7 @@ class TimerAdapter implements org.eclipse.microprofile.metrics.Timer, MeterHolde
             TimerBucketConfiguration bucketsConfig = MetricsConfigurationManager.getInstance()
                     .getTimerBucketConfiguration(metadata.getName());
 
-            DefaulBucketConfiguration defaultBucketConfig = MetricsConfigurationManager.getInstance()
+            DefaultBucketConfiguration defaultBucketConfig = MetricsConfigurationManager.getInstance()
                     .getDefaultBucketConfiguration(metadata.getName());
 
             Set<Tag> tagsSet = new HashSet<Tag>();
@@ -87,7 +87,7 @@ class TimerAdapter implements org.eclipse.microprofile.metrics.Timer, MeterHolde
                 double[] vals = Stream.of(percentilesConfig.getValues()).mapToDouble(Double::doubleValue).toArray();
                 builder = builder.publishPercentiles(vals);
             } else if (percentilesConfig != null && percentilesConfig.getValues() == null
-                    && percentilesConfig.isDisabled() == true) {
+                    && percentilesConfig.isDisabled()) {
                 // do nothing - percentiles were disabled
             } else {
                 builder = builder.publishPercentiles(0.5, 0.75, 0.95, 0.98, 0.99, 0.999);
@@ -97,8 +97,8 @@ class TimerAdapter implements org.eclipse.microprofile.metrics.Timer, MeterHolde
                 builder = builder.serviceLevelObjectives(bucketsConfig.getValues());
             }
 
-            if (defaultBucketConfig != null && defaultBucketConfig.getIsEnabled() == true) {
-                builder = builder.publishPercentileHistogram(defaultBucketConfig.getIsEnabled());
+            if (defaultBucketConfig != null && defaultBucketConfig.isEnabled()) {
+                builder = builder.publishPercentileHistogram(defaultBucketConfig.isEnabled());
 
                 // max and min
                 TimerBucketMaxConfiguration defaultBucketMaxConfig = MetricsConfigurationManager.getInstance()

--- a/implementation/src/main/java/io/smallrye/metrics/setup/config/DefaulBucketConfiguration.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/config/DefaulBucketConfiguration.java
@@ -1,0 +1,53 @@
+package io.smallrye.metrics.setup.config;
+
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.logging.Logger;
+
+public class DefaulBucketConfiguration extends PropertyBooleanConfiguration {
+
+    private static final String CLASS_NAME = DefaulBucketConfiguration.class.getName();
+    private static final Logger LOGGER = Logger.getLogger(CLASS_NAME);
+
+    public DefaulBucketConfiguration(String metricName, boolean value) {
+        this.metricName = metricName;
+        this.isEnabled = value;
+    }
+
+    public static Collection<DefaulBucketConfiguration> parse(String input) {
+
+        ArrayDeque<DefaulBucketConfiguration> metricBucketConfiCollection = new ArrayDeque<DefaulBucketConfiguration>();
+
+        if (input == null || input.length() == 0) {
+            return null;
+        }
+
+        // not expecting backslashes?
+        String[] metricValuePairs = input.split(";");
+
+        // Individual metric name grouping and values
+        for (String kvString : metricValuePairs) {
+
+            String[] keyValueSplit = kvString.split("=");
+
+            String metricName = keyValueSplit[0];
+
+            DefaulBucketConfiguration metricDefaultedBucketConfiguration = null;
+
+            //metricGroup=<blank> => default to false
+            if (keyValueSplit.length == 1) {
+                continue;
+            } else {
+                boolean isEnabledParam = Boolean.parseBoolean(keyValueSplit[1].trim());
+
+                metricDefaultedBucketConfiguration = new DefaulBucketConfiguration(metricName, isEnabledParam);
+            }
+
+            // LIFO - right most configuration takes precedence
+            metricBucketConfiCollection.addFirst(metricDefaultedBucketConfiguration);
+        }
+        return metricBucketConfiCollection;
+
+    }
+
+}

--- a/implementation/src/main/java/io/smallrye/metrics/setup/config/DefaultBucketConfiguration.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/config/DefaultBucketConfiguration.java
@@ -4,19 +4,19 @@ import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.logging.Logger;
 
-public class DefaulBucketConfiguration extends PropertyBooleanConfiguration {
+public class DefaultBucketConfiguration extends PropertyBooleanConfiguration {
 
-    private static final String CLASS_NAME = DefaulBucketConfiguration.class.getName();
+    private static final String CLASS_NAME = DefaultBucketConfiguration.class.getName();
     private static final Logger LOGGER = Logger.getLogger(CLASS_NAME);
 
-    public DefaulBucketConfiguration(String metricName, boolean value) {
+    public DefaultBucketConfiguration(String metricName, boolean value) {
         this.metricName = metricName;
         this.isEnabled = value;
     }
 
-    public static Collection<DefaulBucketConfiguration> parse(String input) {
+    public static Collection<DefaultBucketConfiguration> parse(String input) {
 
-        ArrayDeque<DefaulBucketConfiguration> metricBucketConfiCollection = new ArrayDeque<DefaulBucketConfiguration>();
+        ArrayDeque<DefaultBucketConfiguration> metricBucketConfiCollection = new ArrayDeque<DefaultBucketConfiguration>();
 
         if (input == null || input.length() == 0) {
             return null;
@@ -32,7 +32,7 @@ public class DefaulBucketConfiguration extends PropertyBooleanConfiguration {
 
             String metricName = keyValueSplit[0];
 
-            DefaulBucketConfiguration metricDefaultedBucketConfiguration = null;
+            DefaultBucketConfiguration metricDefaultedBucketConfiguration = null;
 
             //metricGroup=<blank> => default to false
             if (keyValueSplit.length == 1) {
@@ -40,7 +40,7 @@ public class DefaulBucketConfiguration extends PropertyBooleanConfiguration {
             } else {
                 boolean isEnabledParam = Boolean.parseBoolean(keyValueSplit[1].trim());
 
-                metricDefaultedBucketConfiguration = new DefaulBucketConfiguration(metricName, isEnabledParam);
+                metricDefaultedBucketConfiguration = new DefaultBucketConfiguration(metricName, isEnabledParam);
             }
 
             // LIFO - right most configuration takes precedence

--- a/implementation/src/main/java/io/smallrye/metrics/setup/config/HistogramBucketConfiguration.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/config/HistogramBucketConfiguration.java
@@ -1,0 +1,81 @@
+package io.smallrye.metrics.setup.config;
+
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class HistogramBucketConfiguration extends PropertyArrayConfiguration<Double> {
+
+    private static final String CLASS_NAME = HistogramBucketConfiguration.class.getName();
+    private static final Logger LOGGER = Logger.getLogger(CLASS_NAME);
+
+    public HistogramBucketConfiguration(String metricName, Double[] values) {
+        super(metricName, values);
+
+    }
+
+    /**
+     * 
+     * @param input
+     * @return
+     */
+    public static Collection<HistogramBucketConfiguration> parse(String input) {
+
+        ArrayDeque<HistogramBucketConfiguration> metricBucketConfiCollection = new ArrayDeque<HistogramBucketConfiguration>();
+
+        if (input == null || input.length() == 0) {
+            return null;
+        }
+
+        // not expecting backslashes?
+        String[] metricValuePairs = input.split(";");
+
+        // Individual metric name grouping and values
+        for (String kvString : metricValuePairs) {
+
+            String[] keyValueSplit = kvString.split("=");
+
+            String metricName = keyValueSplit[0];
+
+            HistogramBucketConfiguration metricBucketConfiguration = null;
+
+            /*
+             * <metricName>=<blank> --> invalid
+             * Nothing happens and metric name and empty-value is not recorded
+             */
+            if (keyValueSplit.length == 1) {
+                continue;
+            } else {
+                // Parse values of buckets
+                Double[] bucketValues = Arrays.asList(keyValueSplit[1].split(",")).stream()
+                        // .filter(s -> s.matches("[0-9]+[.]*[0-9]*"))
+                        // .map(Double::parseDouble)
+                        .map(s -> {
+                            if (s.matches("[0-9]+[.]*[0-9]*")) {
+                                return Double.parseDouble(s);
+                            } else {
+                                if (LOGGER.isLoggable(Level.FINER)) {
+                                    LOGGER.logp(Level.FINER, CLASS_NAME, null,
+                                            "The value \"{0}\" is invalid for the \"{1}\" property. Only integer "
+                                                    + "and decimal values are accepted.",
+                                            new Object[] { s, MetricsConfigurationManager.MP_HISTOGRAM_BUCKET_PROP });
+                                }
+                                return null;
+                            }
+                        }).filter(x -> x != null).toArray(Double[]::new);
+
+                Arrays.sort(bucketValues);
+
+                metricBucketConfiguration = new HistogramBucketConfiguration(metricName, bucketValues);
+            }
+
+            // LIFO - right most configuration takes precedence
+            metricBucketConfiCollection.addFirst(metricBucketConfiguration);
+        }
+        return metricBucketConfiCollection;
+
+    }
+
+}

--- a/implementation/src/main/java/io/smallrye/metrics/setup/config/HistogramBucketConfiguration.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/config/HistogramBucketConfiguration.java
@@ -50,8 +50,6 @@ public class HistogramBucketConfiguration extends PropertyArrayConfiguration<Dou
             } else {
                 // Parse values of buckets
                 Double[] bucketValues = Arrays.asList(keyValueSplit[1].split(",")).stream()
-                        // .filter(s -> s.matches("[0-9]+[.]*[0-9]*"))
-                        // .map(Double::parseDouble)
                         .map(s -> {
                             if (s.matches("[0-9]+[.]*[0-9]*")) {
                                 return Double.parseDouble(s);

--- a/implementation/src/main/java/io/smallrye/metrics/setup/config/HistogramBucketMaxConfiguration.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/config/HistogramBucketMaxConfiguration.java
@@ -7,7 +7,7 @@ import java.util.logging.Logger;
 
 public class HistogramBucketMaxConfiguration extends PropertySingleValueConfiguration<Double> {
 
-    private static final String CLASS_NAME = HistogramBucketConfiguration.class.getName();
+    private static final String CLASS_NAME = HistogramBucketMaxConfiguration.class.getName();
     private static final Logger LOGGER = Logger.getLogger(CLASS_NAME);
 
     public HistogramBucketMaxConfiguration(String metricName, Double value) {

--- a/implementation/src/main/java/io/smallrye/metrics/setup/config/HistogramBucketMaxConfiguration.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/config/HistogramBucketMaxConfiguration.java
@@ -1,0 +1,62 @@
+package io.smallrye.metrics.setup.config;
+
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class HistogramBucketMaxConfiguration extends PropertySingleValueConfiguration<Double> {
+
+    private static final String CLASS_NAME = HistogramBucketConfiguration.class.getName();
+    private static final Logger LOGGER = Logger.getLogger(CLASS_NAME);
+
+    public HistogramBucketMaxConfiguration(String metricName, Double value) {
+        super(metricName, value);
+    }
+
+    public static Collection<HistogramBucketMaxConfiguration> parse(String input) {
+
+        ArrayDeque<HistogramBucketMaxConfiguration> metricBucketMinMax = new ArrayDeque<HistogramBucketMaxConfiguration>();
+
+        if (input == null || input.length() == 0) {
+            return null;
+        }
+
+        // not expecting backslashes?
+        String[] metricValuePairs = input.split(";");
+
+        // Individual metric name grouping and values
+        for (String kvString : metricValuePairs) {
+
+            String[] keyValueSplit = kvString.split("=");
+
+            String metricName = keyValueSplit[0];
+
+            HistogramBucketMaxConfiguration metricBucketConfiguration = null;
+
+            // metricGroup=<blank> == invalid
+            if (keyValueSplit.length == 2) {
+                if (keyValueSplit[1].matches(("[0-9]+[.]*[0-9]*"))) {
+                    Double value = Double.parseDouble(keyValueSplit[1].trim());
+                    metricBucketConfiguration = new HistogramBucketMaxConfiguration(metricName, value);
+                } else {
+                    if (LOGGER.isLoggable(Level.FINER)) {
+                        LOGGER.logp(Level.FINER, CLASS_NAME, null,
+                                "The value \"{0}\" is invalid for the \"{1}\" property. Only integer "
+                                        + "and decimal values are accepted.",
+                                new Object[] { keyValueSplit[1], MetricsConfigurationManager.MP_HISTOGRAM_BUCKET_PROP });
+                    }
+                }
+            } else {
+                //either no value.. or too many values
+                continue;
+            }
+
+            // LIFO - right most configuration takes precedence
+            metricBucketMinMax.addFirst(metricBucketConfiguration);
+        }
+        return metricBucketMinMax;
+
+    }
+
+}

--- a/implementation/src/main/java/io/smallrye/metrics/setup/config/HistogramBucketMinConfiguration.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/config/HistogramBucketMinConfiguration.java
@@ -7,7 +7,7 @@ import java.util.logging.Logger;
 
 public class HistogramBucketMinConfiguration extends PropertySingleValueConfiguration<Double> {
 
-    private static final String CLASS_NAME = HistogramBucketConfiguration.class.getName();
+    private static final String CLASS_NAME = HistogramBucketMinConfiguration.class.getName();
     private static final Logger LOGGER = Logger.getLogger(CLASS_NAME);
 
     public HistogramBucketMinConfiguration(String metricName, Double value) {

--- a/implementation/src/main/java/io/smallrye/metrics/setup/config/HistogramBucketMinConfiguration.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/config/HistogramBucketMinConfiguration.java
@@ -1,0 +1,62 @@
+package io.smallrye.metrics.setup.config;
+
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class HistogramBucketMinConfiguration extends PropertySingleValueConfiguration<Double> {
+
+    private static final String CLASS_NAME = HistogramBucketConfiguration.class.getName();
+    private static final Logger LOGGER = Logger.getLogger(CLASS_NAME);
+
+    public HistogramBucketMinConfiguration(String metricName, Double value) {
+        super(metricName, value);
+    }
+
+    public static Collection<HistogramBucketMinConfiguration> parse(String input) {
+
+        ArrayDeque<HistogramBucketMinConfiguration> metricBucketMinMax = new ArrayDeque<HistogramBucketMinConfiguration>();
+
+        if (input == null || input.length() == 0) {
+            return null;
+        }
+
+        // not expecting backslashes?
+        String[] metricValuePairs = input.split(";");
+
+        // Individual metric name grouping and values
+        for (String kvString : metricValuePairs) {
+
+            String[] keyValueSplit = kvString.split("=");
+
+            String metricName = keyValueSplit[0];
+
+            HistogramBucketMinConfiguration metricBucketConfiguration = null;
+
+            // metricGroup=<blank> == invalid
+            if (keyValueSplit.length == 2) {
+                if (keyValueSplit[1].matches(("[0-9]+[.]*[0-9]*"))) {
+                    Double value = Double.parseDouble(keyValueSplit[1].trim());
+                    metricBucketConfiguration = new HistogramBucketMinConfiguration(metricName, value);
+                } else {
+                    if (LOGGER.isLoggable(Level.FINER)) {
+                        LOGGER.logp(Level.FINER, CLASS_NAME, null,
+                                "The value \"{0}\" is invalid for the \"{1}\" property. Only integer "
+                                        + "and decimal values are accepted.",
+                                new Object[] { keyValueSplit[1], MetricsConfigurationManager.MP_HISTOGRAM_BUCKET_PROP });
+                    }
+                }
+            } else {
+                //either no value.. or too many values through improper syntax
+                continue;
+            }
+
+            // LIFO - right most configuration takes precedence
+            metricBucketMinMax.addFirst(metricBucketConfiguration);
+        }
+        return metricBucketMinMax;
+
+    }
+
+}

--- a/implementation/src/main/java/io/smallrye/metrics/setup/config/MetricPercentileConfiguration.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/config/MetricPercentileConfiguration.java
@@ -1,0 +1,90 @@
+package io.smallrye.metrics.setup.config;
+
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class MetricPercentileConfiguration extends PropertyArrayConfiguration<Double> {
+    private boolean isDisabled = false;
+
+    private static final String CLASS_NAME = MetricPercentileConfiguration.class.getName();
+    private static final Logger LOGGER = Logger.getLogger(CLASS_NAME);
+
+    public MetricPercentileConfiguration(String metricName, Double[] percentileValues) {
+        super(metricName, percentileValues);
+    }
+
+    public MetricPercentileConfiguration(String metricName, boolean isDisabled) {
+        super(metricName, null);
+        this.isDisabled = isDisabled;
+    }
+
+    public boolean isDisabled() {
+        return isDisabled;
+    }
+
+    /**
+     * 
+     * Parse the `mp.metrics.distribution.percentile` property.
+     * syntax of <metric_name>=<value-1>,<value-2>,...,<value-n>
+     * No values supplied to a metric name disables percentile output.
+     * Can use wild card `*` at the end of metric name (e.g. demo.app.*)
+     * 
+     * @param input MP Config value
+     * @return Collection<MetricPercentileConfiguration> Collection of MetricPercentileConfiguration objects
+     */
+    public static Collection<MetricPercentileConfiguration> parseMetricPercentiles(String input) {
+
+        ArrayDeque<MetricPercentileConfiguration> metricPercentileConfiCollection = new ArrayDeque<MetricPercentileConfiguration>();
+
+        if (input == null || input.length() == 0) {
+            return null;
+        }
+
+        // not expecting backslashes?
+        String[] metricValuePairs = input.split(";");
+
+        // Individual metric name grouping and values
+        for (String kvString : metricValuePairs) {
+
+            String[] keyValueSplit = kvString.split("=");
+
+            String metricName = keyValueSplit[0];
+
+            MetricPercentileConfiguration metricPercentileConfiguration;
+
+            // empty value - disabled
+            if (keyValueSplit.length == 1) {
+                metricPercentileConfiguration = new MetricPercentileConfiguration(metricName, true);
+            } else {
+                // Parse values of percentile - ensure value is 0 <= x <= 1.0
+                Double[] percentileValues = Arrays.asList(keyValueSplit[1].split(",")).stream().map(s -> {
+
+                    if (s.matches("[0][.][0-9]+")) {
+                        return Double.parseDouble(s);
+                    } else {
+                        if (LOGGER.isLoggable(Level.FINER)) {
+                            LOGGER.logp(Level.FINER, CLASS_NAME, null,
+                                    "The value \"{0}\" is invalid for the \"{1}\" property. Only values 0.0-1.0 inclusively are accepted.",
+                                    new Object[] { s, MetricsConfigurationManager.MP_PERCENTILES_PROP });
+                        }
+                        return null;
+                    }
+
+                }).filter(d -> d != null && d >= 0.0 && d <= 1.0).toArray(Double[]::new);
+
+                Arrays.sort(percentileValues);
+
+                metricPercentileConfiguration = new MetricPercentileConfiguration(metricName, percentileValues);
+            }
+
+            // LIFO - right most configuration takes precedence
+            metricPercentileConfiCollection.addFirst(metricPercentileConfiguration);
+        }
+        return metricPercentileConfiCollection;
+
+    }
+
+}

--- a/implementation/src/main/java/io/smallrye/metrics/setup/config/MetricPercentileConfiguration.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/config/MetricPercentileConfiguration.java
@@ -37,7 +37,7 @@ public class MetricPercentileConfiguration extends PropertyArrayConfiguration<Do
      */
     public static Collection<MetricPercentileConfiguration> parseMetricPercentiles(String input) {
 
-        ArrayDeque<MetricPercentileConfiguration> metricPercentileConfiCollection = new ArrayDeque<MetricPercentileConfiguration>();
+        ArrayDeque<MetricPercentileConfiguration> metricPercentileConfigCollection = new ArrayDeque<MetricPercentileConfiguration>();
 
         if (input == null || input.length() == 0) {
             return null;
@@ -81,9 +81,9 @@ public class MetricPercentileConfiguration extends PropertyArrayConfiguration<Do
             }
 
             // LIFO - right most configuration takes precedence
-            metricPercentileConfiCollection.addFirst(metricPercentileConfiguration);
+            metricPercentileConfigCollection.addFirst(metricPercentileConfiguration);
         }
-        return metricPercentileConfiCollection;
+        return metricPercentileConfigCollection;
 
     }
 

--- a/implementation/src/main/java/io/smallrye/metrics/setup/config/MetricsConfigurationManager.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/config/MetricsConfigurationManager.java
@@ -39,7 +39,7 @@ public class MetricsConfigurationManager {
 
     private volatile Map<String, Collection<TimerBucketConfiguration>> timerBucketsConfigMap = new HashMap<String, Collection<TimerBucketConfiguration>>();
 
-    private volatile Map<String, Collection<DefaulBucketConfiguration>> defaultBucketConfigMap = new HashMap<String, Collection<DefaulBucketConfiguration>>();
+    private volatile Map<String, Collection<DefaultBucketConfiguration>> defaultBucketConfigMap = new HashMap<String, Collection<DefaultBucketConfiguration>>();
 
     private volatile Map<String, Collection<HistogramBucketMaxConfiguration>> defaultHistogramBucketMaxConfig = new HashMap<String, Collection<HistogramBucketMaxConfiguration>>();
     private volatile Map<String, Collection<HistogramBucketMinConfiguration>> defaultHistogramBucketMinConfig = new HashMap<String, Collection<HistogramBucketMinConfiguration>>();
@@ -55,10 +55,10 @@ public class MetricsConfigurationManager {
     }
 
     /**
-     * Returns the matching configuration object if it exists, null otherwise
+     * Returns the matching {@link MetricPercentileConfiguration} object if it exists, null otherwise
      * 
      * @param metricName the metric name to check configuration against
-     * @return the matching configuration object if it exists, null otherwise
+     * @return the matching {@link MetricPercentileConfiguration} object if it exists, null otherwise
      */
     public synchronized MetricPercentileConfiguration getPercentilesConfiguration(String metricName) {
 
@@ -85,12 +85,12 @@ public class MetricsConfigurationManager {
     }
 
     /**
-     * Returns the matching configuration object if it exists, null otherwise
+     * Returns the matching {@link HistogramBucketConfiguration} object if it exists, null otherwise
      * 
      * @param metricName the metric name to check configuration against
-     * @return the matching configuration object if it exists, null otherwise
+     * @return the matching {@link HistogramBucketConfiguration} object if it exists, null otherwise
      */
-    public synchronized HistogramBucketConfiguration getHistogrmBucketConfiguration(String metricName) {
+    public synchronized HistogramBucketConfiguration getHistogramBucketConfiguration(String metricName) {
 
         String appName = getApplicationName();
 
@@ -107,7 +107,7 @@ public class MetricsConfigurationManager {
             HistogramBucketConfiguration retVal = HistogramBucketConfiguration.matches(computedValues, metricName);
             if (LOGGER.isLoggable(Level.FINEST)) {
                 LOGGER.logp(Level.FINEST, CLASS_NAME, null,
-                        "Returning \"{0}\" configuration for metric:\"{1}\" with values: {1} ",
+                        "Returning \"{0}\" configuration for metric:\"{1}\" with values: {2} ",
                         new Object[] { MP_HISTOGRAM_BUCKET_PROP, metricName, retVal });
             }
             return retVal;
@@ -117,10 +117,10 @@ public class MetricsConfigurationManager {
     }
 
     /**
-     * Returns the matching configuration object if it exists, null otherwise
+     * Returns the matching {@link TimerBucketConfiguration} object if it exists, null otherwise
      * 
      * @param metricName the metric name to check configuration against
-     * @return the matching configuration object if it exists, null otherwise
+     * @return the matching {@link TimerBucketConfiguration} object if it exists, null otherwise
      */
     public synchronized TimerBucketConfiguration getTimerBucketConfiguration(String metricName) {
 
@@ -137,7 +137,7 @@ public class MetricsConfigurationManager {
             TimerBucketConfiguration retVal = TimerBucketConfiguration.matches(computedValues, metricName);
             if (LOGGER.isLoggable(Level.FINEST)) {
                 LOGGER.logp(Level.FINEST, CLASS_NAME, null,
-                        "Returning \"{0}\" configuration for metric:\"{0}\" with values: {1} ",
+                        "Returning \"{0}\" configuration for metric:\"{1}\" with values: {2} ",
                         new Object[] { MP_TIMER_BUCKET_PROP, metricName, retVal });
             }
             return retVal;
@@ -147,27 +147,27 @@ public class MetricsConfigurationManager {
     }
 
     /**
-     * Returns the matching configuration object if it exists, null otherwise
+     * Returns the matching {@link DefaultBucketConfiguration} object if it exists, null otherwise
      * 
      * @param metricName the metric name to check configuration against
-     * @return the matching configuration object if it exists, null otherwise
+     * @return the matching {@link DefaultBucketConfiguration} object if it exists, null otherwise
      */
-    public synchronized DefaulBucketConfiguration getDefaultBucketConfiguration(String metricName) {
+    public synchronized DefaultBucketConfiguration getDefaultBucketConfiguration(String metricName) {
 
         String appName = getApplicationName();
 
-        Collection<DefaulBucketConfiguration> computedValues = defaultBucketConfigMap.computeIfAbsent(appName, f -> {
+        Collection<DefaultBucketConfiguration> computedValues = defaultBucketConfigMap.computeIfAbsent(appName, f -> {
             Optional<String> input = ConfigProvider.getConfig().getOptionalValue(MP_DEFAULT_BUCKET_PROP, String.class);
 
-            return (input.isPresent()) ? DefaulBucketConfiguration.parse(input.get()) : null;
+            return (input.isPresent()) ? DefaultBucketConfiguration.parse(input.get()) : null;
 
         });
 
         if (computedValues != null && computedValues.size() != 0) {
-            DefaulBucketConfiguration retVal = DefaulBucketConfiguration.matches(computedValues, metricName);
+            DefaultBucketConfiguration retVal = DefaultBucketConfiguration.matches(computedValues, metricName);
             if (LOGGER.isLoggable(Level.FINEST)) {
                 LOGGER.logp(Level.FINEST, CLASS_NAME, null,
-                        "Returning \"{0}\" configuration for metric:\"{0}\" with values: {1} ",
+                        "Returning \"{0}\" configuration for metric:\"{1}\" with values: {2} ",
                         new Object[] { MP_DEFAULT_BUCKET_PROP, metricName, retVal });
             }
             return retVal;
@@ -178,10 +178,10 @@ public class MetricsConfigurationManager {
     }
 
     /**
-     * Returns the matching configuration object if it exists, null otherwise
+     * Returns the matching {@link HistogramBucketMaxConfiguration} object if it exists, null otherwise
      * 
      * @param metricName the metric name to check configuration against
-     * @return the matching configuration object if it exists, null otherwise
+     * @return the matching {@link HistogramBucketMaxConfiguration} object if it exists, null otherwise
      */
     public synchronized HistogramBucketMaxConfiguration getDefaultHistogramMaxBucketConfiguration(String metricName) {
 
@@ -201,7 +201,7 @@ public class MetricsConfigurationManager {
                     metricName);
             if (LOGGER.isLoggable(Level.FINEST)) {
                 LOGGER.logp(Level.FINEST, CLASS_NAME, null,
-                        "Returning \"{0}\" configuration for metric:\"{0}\" with values: {1} ",
+                        "Returning \"{0}\" configuration for metric:\"{1}\" with values: {2} ",
                         new Object[] { MP_HISTOGRAM_MAX_CONFIG, metricName, retVal });
             }
             return retVal;
@@ -211,10 +211,10 @@ public class MetricsConfigurationManager {
     }
 
     /**
-     * Returns the matching configuration object if it exists, null otherwise
+     * Returns the matching {@link HistogramBucketMinConfiguration} object if it exists, null otherwise
      * 
      * @param metricName the metric name to check configuration against
-     * @return the matching configuration object if it exists, null otherwise
+     * @return the matching {@link HistogramBucketMinConfiguration} object if it exists, null otherwise
      */
     public synchronized HistogramBucketMinConfiguration getDefaultHistogramMinBucketConfiguration(String metricName) {
 
@@ -234,7 +234,7 @@ public class MetricsConfigurationManager {
                     metricName);
             if (LOGGER.isLoggable(Level.FINEST)) {
                 LOGGER.logp(Level.FINEST, CLASS_NAME, null,
-                        "Returning \"{0}\" configuration for metric:\"{0}\" with values: {1} ",
+                        "Returning \"{0}\" configuration for metric:\"{1}\" with values: {2} ",
                         new Object[] { MP_HISTOGRAM_MIN_CONFIG, metricName, retVal });
             }
             return retVal;
@@ -244,10 +244,10 @@ public class MetricsConfigurationManager {
     }
 
     /**
-     * Returns the matching configuration object if it exists, null otherwise
+     * Returns the matching {@link TimerBucketMaxConfiguration} object if it exists, null otherwise
      * 
      * @param metricName the metric name to check configuration against
-     * @return the matching configuration object if it exists, null otherwise
+     * @return the matching {@link TimerBucketMaxConfiguration} object if it exists, null otherwise
      */
     public synchronized TimerBucketMaxConfiguration getDefaultTimerMaxBucketConfiguration(String metricName) {
 
@@ -265,7 +265,7 @@ public class MetricsConfigurationManager {
             TimerBucketMaxConfiguration retVal = TimerBucketMaxConfiguration.matches(computedValues, metricName);
             if (LOGGER.isLoggable(Level.FINEST)) {
                 LOGGER.logp(Level.FINEST, CLASS_NAME, null,
-                        "Returning \"{0}\" configuration for metric:\"{0}\" with values: {1} ",
+                        "Returning \"{0}\" configuration for metric:\"{1}\" with values: {2} ",
                         new Object[] { MP_TIMER_MAX_CONFIG, metricName, retVal });
             }
             return retVal;
@@ -275,10 +275,10 @@ public class MetricsConfigurationManager {
     }
 
     /**
-     * Returns the matching configuration object if it exists, null otherwise
+     * Returns the matching {@link TimerBucketMinConfiguration} object if it exists, null otherwise
      * 
      * @param metricName the metric name to check configuration against
-     * @return the matching configuration object if it exists, null otherwise
+     * @return the matching {@link TimerBucketMinConfiguration} object if it exists, null otherwise
      */
     public synchronized TimerBucketMinConfiguration getDefaultTimerMinBucketConfiguration(String metricName) {
 
@@ -296,8 +296,8 @@ public class MetricsConfigurationManager {
             TimerBucketMinConfiguration retVal = TimerBucketMinConfiguration.matches(computedValues, metricName);
             if (LOGGER.isLoggable(Level.FINEST)) {
                 LOGGER.logp(Level.FINEST, CLASS_NAME, null,
-                        "Returning \"{0}\" configuration for metric:\"{0}\" with values: {1} ",
-                        new Object[] { MP_TIMER_MAX_CONFIG, metricName, retVal });
+                        "Returning \"{0}\" configuration for metric:\"{1}\" with values: {2} ",
+                        new Object[] { MP_TIMER_MIN_CONFIG, metricName, retVal });
             }
             return retVal;
         }

--- a/implementation/src/main/java/io/smallrye/metrics/setup/config/MetricsConfigurationManager.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/config/MetricsConfigurationManager.java
@@ -1,0 +1,320 @@
+package io.smallrye.metrics.setup.config;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import io.smallrye.metrics.SharedMetricRegistries;
+import io.smallrye.metrics.setup.ApplicationNameResolver;
+
+public class MetricsConfigurationManager {
+
+    private static final String CLASS_NAME = MetricsConfigurationManager.class.getName();
+    private static final Logger LOGGER = Logger.getLogger(CLASS_NAME);
+
+    private ApplicationNameResolver anr = SharedMetricRegistries.getAppNameResolver();
+
+    static final String MP_PERCENTILES_PROP = "mp.metrics.distribution.percentiles";
+    static final String MP_HISTOGRAM_BUCKET_PROP = "mp.metrics.distribution.histogram.buckets";
+    static final String MP_TIMER_BUCKET_PROP = "mp.metrics.distribution.timer.buckets";
+    static final String MP_DEFAULT_BUCKET_PROP = "mp.metrics.distribution.percentiles-histogram.enabled";
+    static final String MP_HISTOGRAM_MAX_CONFIG = "mp.metrics.distribution.histogram.max-value";
+    static final String MP_HISTOGRAM_MIN_CONFIG = "mp.metrics.distribution.histogram.min-value";
+    static final String MP_TIMER_MAX_CONFIG = "mp.metrics.distribution.timer.max-value";
+    static final String MP_TIMER_MIN_CONFIG = "mp.metrics.distribution.timer.min-value";
+
+    private static MetricsConfigurationManager instance;
+
+    private MetricsConfigurationManager() {
+    };
+
+    private volatile Map<String, Collection<MetricPercentileConfiguration>> percentilesConfigMap = new HashMap<String, Collection<MetricPercentileConfiguration>>();
+
+    private volatile Map<String, Collection<HistogramBucketConfiguration>> histogramBucketsConfigMap = new HashMap<String, Collection<HistogramBucketConfiguration>>();;
+
+    private volatile Map<String, Collection<TimerBucketConfiguration>> timerBucketsConfigMap = new HashMap<String, Collection<TimerBucketConfiguration>>();
+
+    private volatile Map<String, Collection<DefaulBucketConfiguration>> defaultBucketConfigMap = new HashMap<String, Collection<DefaulBucketConfiguration>>();
+
+    private volatile Map<String, Collection<HistogramBucketMaxConfiguration>> defaultHistogramBucketMaxConfig = new HashMap<String, Collection<HistogramBucketMaxConfiguration>>();
+    private volatile Map<String, Collection<HistogramBucketMinConfiguration>> defaultHistogramBucketMinConfig = new HashMap<String, Collection<HistogramBucketMinConfiguration>>();
+
+    private volatile Map<String, Collection<TimerBucketMaxConfiguration>> defaultTimerBucketMaxConfig = new HashMap<String, Collection<TimerBucketMaxConfiguration>>();
+    private volatile Map<String, Collection<TimerBucketMinConfiguration>> defaultTimerBucketMinConfig = new HashMap<String, Collection<TimerBucketMinConfiguration>>();
+
+    public static synchronized MetricsConfigurationManager getInstance() {
+        if (instance == null) {
+            instance = new MetricsConfigurationManager();
+        }
+        return instance;
+    }
+
+    /**
+     * Returns the matching configuration object if it exists, null otherwise
+     * 
+     * @param metricName the metric name to check configuration against
+     * @return the matching configuration object if it exists, null otherwise
+     */
+    public synchronized MetricPercentileConfiguration getPercentilesConfiguration(String metricName) {
+
+        String appName = getApplicationName();
+
+        Collection<MetricPercentileConfiguration> computedValues = percentilesConfigMap.computeIfAbsent(appName, f -> {
+            Optional<String> input = ConfigProvider.getConfig().getOptionalValue(MP_PERCENTILES_PROP, String.class);
+
+            return (input.isPresent()) ? MetricPercentileConfiguration.parseMetricPercentiles(input.get()) : null;
+
+        });
+
+        if (computedValues != null && computedValues.size() != 0) {
+            MetricPercentileConfiguration retVal = MetricPercentileConfiguration.matches(computedValues, metricName);
+            if (LOGGER.isLoggable(Level.FINEST)) {
+                LOGGER.logp(Level.FINEST, CLASS_NAME, null,
+                        "Returning \"{0}\" configuration for metric:\"{0}\" with values: {1} ",
+                        new Object[] { MP_PERCENTILES_PROP, metricName, retVal });
+            }
+            return retVal;
+        }
+        return null;
+
+    }
+
+    /**
+     * Returns the matching configuration object if it exists, null otherwise
+     * 
+     * @param metricName the metric name to check configuration against
+     * @return the matching configuration object if it exists, null otherwise
+     */
+    public synchronized HistogramBucketConfiguration getHistogrmBucketConfiguration(String metricName) {
+
+        String appName = getApplicationName();
+
+        Collection<HistogramBucketConfiguration> computedValues = histogramBucketsConfigMap.computeIfAbsent(appName,
+                f -> {
+                    Optional<String> input = ConfigProvider.getConfig().getOptionalValue(MP_HISTOGRAM_BUCKET_PROP,
+                            String.class);
+
+                    return (input.isPresent()) ? HistogramBucketConfiguration.parse(input.get()) : null;
+
+                });
+
+        if (computedValues != null && computedValues.size() != 0) {
+            HistogramBucketConfiguration retVal = HistogramBucketConfiguration.matches(computedValues, metricName);
+            if (LOGGER.isLoggable(Level.FINEST)) {
+                LOGGER.logp(Level.FINEST, CLASS_NAME, null,
+                        "Returning \"{0}\" configuration for metric:\"{1}\" with values: {1} ",
+                        new Object[] { MP_HISTOGRAM_BUCKET_PROP, metricName, retVal });
+            }
+            return retVal;
+        }
+        return null;
+
+    }
+
+    /**
+     * Returns the matching configuration object if it exists, null otherwise
+     * 
+     * @param metricName the metric name to check configuration against
+     * @return the matching configuration object if it exists, null otherwise
+     */
+    public synchronized TimerBucketConfiguration getTimerBucketConfiguration(String metricName) {
+
+        String appName = getApplicationName();
+
+        Collection<TimerBucketConfiguration> computedValues = timerBucketsConfigMap.computeIfAbsent(appName, f -> {
+            Optional<String> input = ConfigProvider.getConfig().getOptionalValue(MP_TIMER_BUCKET_PROP, String.class);
+
+            return (input.isPresent()) ? TimerBucketConfiguration.parse(input.get()) : null;
+
+        });
+
+        if (computedValues != null && computedValues.size() != 0) {
+            TimerBucketConfiguration retVal = TimerBucketConfiguration.matches(computedValues, metricName);
+            if (LOGGER.isLoggable(Level.FINEST)) {
+                LOGGER.logp(Level.FINEST, CLASS_NAME, null,
+                        "Returning \"{0}\" configuration for metric:\"{0}\" with values: {1} ",
+                        new Object[] { MP_TIMER_BUCKET_PROP, metricName, retVal });
+            }
+            return retVal;
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the matching configuration object if it exists, null otherwise
+     * 
+     * @param metricName the metric name to check configuration against
+     * @return the matching configuration object if it exists, null otherwise
+     */
+    public synchronized DefaulBucketConfiguration getDefaultBucketConfiguration(String metricName) {
+
+        String appName = getApplicationName();
+
+        Collection<DefaulBucketConfiguration> computedValues = defaultBucketConfigMap.computeIfAbsent(appName, f -> {
+            Optional<String> input = ConfigProvider.getConfig().getOptionalValue(MP_DEFAULT_BUCKET_PROP, String.class);
+
+            return (input.isPresent()) ? DefaulBucketConfiguration.parse(input.get()) : null;
+
+        });
+
+        if (computedValues != null && computedValues.size() != 0) {
+            DefaulBucketConfiguration retVal = DefaulBucketConfiguration.matches(computedValues, metricName);
+            if (LOGGER.isLoggable(Level.FINEST)) {
+                LOGGER.logp(Level.FINEST, CLASS_NAME, null,
+                        "Returning \"{0}\" configuration for metric:\"{0}\" with values: {1} ",
+                        new Object[] { MP_DEFAULT_BUCKET_PROP, metricName, retVal });
+            }
+            return retVal;
+        }
+
+        return null;
+
+    }
+
+    /**
+     * Returns the matching configuration object if it exists, null otherwise
+     * 
+     * @param metricName the metric name to check configuration against
+     * @return the matching configuration object if it exists, null otherwise
+     */
+    public synchronized HistogramBucketMaxConfiguration getDefaultHistogramMaxBucketConfiguration(String metricName) {
+
+        String appName = getApplicationName();
+
+        Collection<HistogramBucketMaxConfiguration> computedValues = defaultHistogramBucketMaxConfig
+                .computeIfAbsent(appName, f -> {
+                    Optional<String> input = ConfigProvider.getConfig().getOptionalValue(MP_HISTOGRAM_MAX_CONFIG,
+                            String.class);
+
+                    return (input.isPresent()) ? HistogramBucketMaxConfiguration.parse(input.get()) : null;
+
+                });
+
+        if (computedValues != null && computedValues.size() != 0) {
+            HistogramBucketMaxConfiguration retVal = HistogramBucketMaxConfiguration.matches(computedValues,
+                    metricName);
+            if (LOGGER.isLoggable(Level.FINEST)) {
+                LOGGER.logp(Level.FINEST, CLASS_NAME, null,
+                        "Returning \"{0}\" configuration for metric:\"{0}\" with values: {1} ",
+                        new Object[] { MP_HISTOGRAM_MAX_CONFIG, metricName, retVal });
+            }
+            return retVal;
+        }
+        return null;
+
+    }
+
+    /**
+     * Returns the matching configuration object if it exists, null otherwise
+     * 
+     * @param metricName the metric name to check configuration against
+     * @return the matching configuration object if it exists, null otherwise
+     */
+    public synchronized HistogramBucketMinConfiguration getDefaultHistogramMinBucketConfiguration(String metricName) {
+
+        String appName = getApplicationName();
+
+        Collection<HistogramBucketMinConfiguration> computedValues = defaultHistogramBucketMinConfig
+                .computeIfAbsent(appName, f -> {
+                    Optional<String> input = ConfigProvider.getConfig().getOptionalValue(MP_HISTOGRAM_MIN_CONFIG,
+                            String.class);
+
+                    return (input.isPresent()) ? HistogramBucketMinConfiguration.parse(input.get()) : null;
+
+                });
+
+        if (computedValues != null && computedValues.size() != 0) {
+            HistogramBucketMinConfiguration retVal = HistogramBucketMinConfiguration.matches(computedValues,
+                    metricName);
+            if (LOGGER.isLoggable(Level.FINEST)) {
+                LOGGER.logp(Level.FINEST, CLASS_NAME, null,
+                        "Returning \"{0}\" configuration for metric:\"{0}\" with values: {1} ",
+                        new Object[] { MP_HISTOGRAM_MIN_CONFIG, metricName, retVal });
+            }
+            return retVal;
+        }
+        return null;
+
+    }
+
+    /**
+     * Returns the matching configuration object if it exists, null otherwise
+     * 
+     * @param metricName the metric name to check configuration against
+     * @return the matching configuration object if it exists, null otherwise
+     */
+    public synchronized TimerBucketMaxConfiguration getDefaultTimerMaxBucketConfiguration(String metricName) {
+
+        String appName = getApplicationName();
+
+        Collection<TimerBucketMaxConfiguration> computedValues = defaultTimerBucketMaxConfig.computeIfAbsent(appName,
+                f -> {
+                    Optional<String> input = ConfigProvider.getConfig().getOptionalValue(MP_TIMER_MAX_CONFIG, String.class);
+
+                    return (input.isPresent()) ? TimerBucketMaxConfiguration.parse(input.get()) : null;
+
+                });
+
+        if (computedValues != null && computedValues.size() != 0) {
+            TimerBucketMaxConfiguration retVal = TimerBucketMaxConfiguration.matches(computedValues, metricName);
+            if (LOGGER.isLoggable(Level.FINEST)) {
+                LOGGER.logp(Level.FINEST, CLASS_NAME, null,
+                        "Returning \"{0}\" configuration for metric:\"{0}\" with values: {1} ",
+                        new Object[] { MP_TIMER_MAX_CONFIG, metricName, retVal });
+            }
+            return retVal;
+        }
+        return null;
+
+    }
+
+    /**
+     * Returns the matching configuration object if it exists, null otherwise
+     * 
+     * @param metricName the metric name to check configuration against
+     * @return the matching configuration object if it exists, null otherwise
+     */
+    public synchronized TimerBucketMinConfiguration getDefaultTimerMinBucketConfiguration(String metricName) {
+
+        String appName = getApplicationName();
+
+        Collection<TimerBucketMinConfiguration> computedValues = defaultTimerBucketMinConfig.computeIfAbsent(appName,
+                f -> {
+                    Optional<String> input = ConfigProvider.getConfig().getOptionalValue(MP_TIMER_MIN_CONFIG, String.class);
+
+                    return (input.isPresent()) ? TimerBucketMinConfiguration.parse(input.get()) : null;
+
+                });
+
+        if (computedValues != null && computedValues.size() != 0) {
+            TimerBucketMinConfiguration retVal = TimerBucketMinConfiguration.matches(computedValues, metricName);
+            if (LOGGER.isLoggable(Level.FINEST)) {
+                LOGGER.logp(Level.FINEST, CLASS_NAME, null,
+                        "Returning \"{0}\" configuration for metric:\"{0}\" with values: {1} ",
+                        new Object[] { MP_TIMER_MAX_CONFIG, metricName, retVal });
+            }
+            return retVal;
+        }
+        return null;
+
+    }
+
+    /**
+     * 
+     * @return the application name if it can be resolved, null otherwise
+     */
+    private String getApplicationName() {
+        String appName = null;
+        if (anr != null) {
+            appName = anr.getApplicationName();
+        }
+        return appName;
+    }
+
+}

--- a/implementation/src/main/java/io/smallrye/metrics/setup/config/PropertyArrayConfiguration.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/config/PropertyArrayConfiguration.java
@@ -1,0 +1,23 @@
+package io.smallrye.metrics.setup.config;
+
+import java.util.Arrays;
+
+public abstract class PropertyArrayConfiguration<T> extends PropertyConfiguration {
+    protected T[] values = null;
+
+    public PropertyArrayConfiguration(String metricName, T[] values) {
+        this.metricName = metricName;
+        this.values = values;
+    }
+
+    @Override
+    public String toString() {
+        return String.format(this.getClass().getName() + "<Metric name: [%s]>; <values: %s>", metricName,
+                Arrays.toString(values));
+    }
+
+    public T[] getValues() {
+        return values;
+    }
+
+}

--- a/implementation/src/main/java/io/smallrye/metrics/setup/config/PropertyBooleanConfiguration.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/config/PropertyBooleanConfiguration.java
@@ -9,7 +9,7 @@ public abstract class PropertyBooleanConfiguration extends PropertyConfiguration
                 isEnabled);
     }
 
-    public boolean getIsEnabled() {
+    public boolean isEnabled() {
         return isEnabled;
     }
 }

--- a/implementation/src/main/java/io/smallrye/metrics/setup/config/PropertyBooleanConfiguration.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/config/PropertyBooleanConfiguration.java
@@ -1,0 +1,15 @@
+package io.smallrye.metrics.setup.config;
+
+public abstract class PropertyBooleanConfiguration extends PropertyConfiguration {
+    protected boolean isEnabled = false;
+
+    @Override
+    public String toString() {
+        return String.format(this.getClass().getName() + "metric name: [%s]; isEnabled: [%s]", metricName,
+                isEnabled);
+    }
+
+    public boolean getIsEnabled() {
+        return isEnabled;
+    }
+}

--- a/implementation/src/main/java/io/smallrye/metrics/setup/config/PropertyConfiguration.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/config/PropertyConfiguration.java
@@ -1,0 +1,42 @@
+package io.smallrye.metrics.setup.config;
+
+import java.util.Collection;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public abstract class PropertyConfiguration {
+
+    protected String metricName;
+
+    public String getMetricNameGrouping() {
+        return metricName;
+    }
+
+    /**
+     * Given a metric name and a collection of PropertyConfiguration objects, will return a match to the
+     * metric name if it exists, otherwise a null is returned.
+     * 
+     * @param <T> extends PropertyConfiguration
+     * @param configs Collection of T
+     * @param metricName the metric name to find a matching configuration for
+     * @return the matching configuration or null if non exists.
+     */
+    public static <T extends PropertyConfiguration> T matches(Collection<T> configs, String metricName) {
+        for (PropertyConfiguration histoConfig : configs) {
+
+            if (histoConfig.getMetricNameGrouping().contentEquals("*")) {
+                return (T) histoConfig;
+            }
+
+            Pattern p = Pattern.compile(histoConfig.getMetricNameGrouping());
+            Matcher m = p.matcher(metricName.trim());
+
+            if (m.matches()) {
+                return (T) histoConfig;
+            }
+
+        }
+        return null;
+    }
+
+}

--- a/implementation/src/main/java/io/smallrye/metrics/setup/config/PropertySingleValueConfiguration.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/config/PropertySingleValueConfiguration.java
@@ -1,0 +1,20 @@
+package io.smallrye.metrics.setup.config;
+
+public abstract class PropertySingleValueConfiguration<T> extends PropertyConfiguration {
+    protected T value = null;
+
+    public PropertySingleValueConfiguration(String metricName, T value) {
+        this.metricName = metricName;
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return String.format(this.getClass().getName() + "<Metric name: [%s]>; <value: %s>", metricName,
+                value);
+    }
+
+    public T getValue() {
+        return value;
+    }
+}

--- a/implementation/src/main/java/io/smallrye/metrics/setup/config/TimerBucketConfiguration.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/config/TimerBucketConfiguration.java
@@ -1,0 +1,80 @@
+package io.smallrye.metrics.setup.config;
+
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class TimerBucketConfiguration extends PropertyArrayConfiguration<Duration> {
+
+    private static final String CLASS_NAME = TimerBucketConfiguration.class.getName();
+    private static final Logger LOGGER = Logger.getLogger(CLASS_NAME);
+
+    public TimerBucketConfiguration(String metricName, Duration[] values) {
+        super(metricName, values);
+    }
+
+    public static Collection<TimerBucketConfiguration> parse(String input) {
+
+        ArrayDeque<TimerBucketConfiguration> metricSLOConfiguration = new ArrayDeque<TimerBucketConfiguration>();
+
+        if (input == null || input.length() == 0) {
+            return null;
+        }
+
+        // not expecting backslashes?
+        String[] metricValuePairs = input.split(";");
+
+        // Individual metric name grouping and values
+        for (String kvString : metricValuePairs) {
+
+            String[] keyValueSplit = kvString.split("=");
+
+            String metricName = keyValueSplit[0];
+
+            TimerBucketConfiguration metricBucketConfiguration = null;
+
+            // metricGroup=<blank> == invalid
+            if (keyValueSplit.length == 1) {
+                continue;
+            } else {
+                // Parse values
+                Duration[] arrDuration = Arrays.asList(keyValueSplit[1].split(",")).stream().map(s -> {
+                    s = s.trim();
+                    if (s.matches("[0-9]+ms")) {
+                        String val = s.substring(0, s.length() - 2);
+                        return Duration.ofMillis(Long.parseLong(val));
+                    } else if (s.matches("[0-9]+s")) {
+                        String val = s.substring(0, s.length() - 1);
+                        return Duration.ofSeconds(Long.parseLong(val));
+                    } else if (s.matches("[0-9]+m")) {
+                        String val = s.substring(0, s.length() - 1);
+                        return Duration.ofMinutes(Long.parseLong(val));
+                    } else if (s.matches("[0-9]+h")) {
+                        String val = s.substring(0, s.length() - 1);
+                        return Duration.ofHours(Long.parseLong(val));
+                    } else if (s.matches("[0-9]+")) {
+                        return Duration.ofMillis(Long.parseLong(s));
+                    } else {
+                        if (LOGGER.isLoggable(Level.FINER)) {
+                            LOGGER.logp(Level.FINER, CLASS_NAME, null,
+                                    "The value \"{0}\" is invalid for the \"{1}\" property. Only integer values with an "
+                                            + "optional time unit (e.g. ms,s,m,h) are accepted.",
+                                    new Object[] { s, MetricsConfigurationManager.MP_TIMER_BUCKET_PROP });
+                        }
+                        return null;
+                    }
+                }).filter(s -> s != null).toArray(Duration[]::new);
+                metricBucketConfiguration = new TimerBucketConfiguration(metricName, arrDuration);
+            }
+
+            // LIFO - right most configuration takes precedence
+            metricSLOConfiguration.addFirst(metricBucketConfiguration);
+        }
+        return metricSLOConfiguration;
+
+    }
+
+}

--- a/implementation/src/main/java/io/smallrye/metrics/setup/config/TimerBucketMaxConfiguration.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/config/TimerBucketMaxConfiguration.java
@@ -1,0 +1,81 @@
+package io.smallrye.metrics.setup.config;
+
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class TimerBucketMaxConfiguration extends PropertySingleValueConfiguration<Duration> {
+
+    private static final String CLASS_NAME = TimerBucketMaxConfiguration.class.getName();
+    private static final Logger LOGGER = Logger.getLogger(CLASS_NAME);
+
+    public TimerBucketMaxConfiguration(String metricName, Duration value) {
+        super(metricName, value);
+    }
+
+    public static Collection<TimerBucketMaxConfiguration> parse(String input) {
+
+        ArrayDeque<TimerBucketMaxConfiguration> sloMinConfigCollection = new ArrayDeque<TimerBucketMaxConfiguration>();
+
+        if (input == null || input.length() == 0) {
+            return null;
+        }
+
+        // not expecting backslashes?
+        String[] metricValuePairs = input.split(";");
+
+        // Individual metric name grouping and values
+        for (String kvString : metricValuePairs) {
+
+            String[] keyValueSplit = kvString.split("=");
+
+            String metricName = keyValueSplit[0];
+
+            TimerBucketMaxConfiguration sloMinConfiguration = null;
+            Duration dur;
+            // metricGroup=<blank> == invalid
+            if (keyValueSplit.length == 2) {
+
+                String s = keyValueSplit[1];
+
+                if (s.matches("[0-9]+ms")) {
+                    String val = s.substring(0, s.length() - 2);
+                    dur = Duration.ofMillis(Long.parseLong(val));
+                } else if (s.matches("[0-9]+s")) {
+                    String val = s.substring(0, s.length() - 1);
+                    dur = Duration.ofSeconds(Long.parseLong(val));
+                } else if (s.matches("[0-9]+m")) {
+                    String val = s.substring(0, s.length() - 1);
+                    dur = Duration.ofMinutes(Long.parseLong(val));
+                } else if (s.matches("[0-9]+h")) {
+                    String val = s.substring(0, s.length() - 1);
+                    dur = Duration.ofHours(Long.parseLong(val));
+                } else if (s.matches("[0-9]+")) {
+                    dur = Duration.ofSeconds(Long.parseLong(s));
+                } else {
+                    if (LOGGER.isLoggable(Level.FINER)) {
+                        LOGGER.logp(Level.FINER, CLASS_NAME, null,
+                                "The value \"{0}\" is invalid for the \"{1}\" property. Only integer values with an "
+                                        + "optional time unit (e.g. ms,s,m,h) are accepted.",
+                                new Object[] { s, MetricsConfigurationManager.MP_TIMER_BUCKET_PROP });
+                    }
+                    return null;
+                }
+
+            } else {
+                //either no value.. or too many values through improper syntax
+                continue;
+            }
+
+            sloMinConfiguration = new TimerBucketMaxConfiguration(metricName, dur);
+
+            // LIFO - right most configuration takes precedence
+            sloMinConfigCollection.addFirst(sloMinConfiguration);
+        }
+        return sloMinConfigCollection;
+
+    }
+
+}

--- a/implementation/src/main/java/io/smallrye/metrics/setup/config/TimerBucketMinConfiguration.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/config/TimerBucketMinConfiguration.java
@@ -1,0 +1,81 @@
+package io.smallrye.metrics.setup.config;
+
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class TimerBucketMinConfiguration extends PropertySingleValueConfiguration<Duration> {
+
+    private static final String CLASS_NAME = TimerBucketMinConfiguration.class.getName();
+    private static final Logger LOGGER = Logger.getLogger(CLASS_NAME);
+
+    public TimerBucketMinConfiguration(String metricName, Duration value) {
+        super(metricName, value);
+    }
+
+    public static Collection<TimerBucketMinConfiguration> parse(String input) {
+
+        ArrayDeque<TimerBucketMinConfiguration> sloMinConfigCollection = new ArrayDeque<TimerBucketMinConfiguration>();
+
+        if (input == null || input.length() == 0) {
+            return null;
+        }
+
+        // not expecting backslashes?
+        String[] metricValuePairs = input.split(";");
+
+        // Individual metric name grouping and values
+        for (String kvString : metricValuePairs) {
+
+            String[] keyValueSplit = kvString.split("=");
+
+            String metricName = keyValueSplit[0];
+
+            TimerBucketMinConfiguration sloMinConfiguration = null;
+            Duration dur;
+            // metricGroup=<blank> == invalid
+            if (keyValueSplit.length == 2) {
+
+                String s = keyValueSplit[1];
+
+                if (s.matches("[0-9]+ms")) {
+                    String val = s.substring(0, s.length() - 2);
+                    dur = Duration.ofMillis(Long.parseLong(val));
+                } else if (s.matches("[0-9]+s")) {
+                    String val = s.substring(0, s.length() - 1);
+                    dur = Duration.ofSeconds(Long.parseLong(val));
+                } else if (s.matches("[0-9]+m")) {
+                    String val = s.substring(0, s.length() - 1);
+                    dur = Duration.ofMinutes(Long.parseLong(val));
+                } else if (s.matches("[0-9]+h")) {
+                    String val = s.substring(0, s.length() - 1);
+                    dur = Duration.ofHours(Long.parseLong(val));
+                } else if (s.matches("[0-9]+")) {
+                    dur = Duration.ofSeconds(Long.parseLong(s));
+                } else {
+                    if (LOGGER.isLoggable(Level.FINER)) {
+                        LOGGER.logp(Level.FINER, CLASS_NAME, null,
+                                "The value \"{0}\" is invalid for the \"{1}\" property. Only integer values with an "
+                                        + "optional time unit (e.g. ms,s,m,h) are accepted.",
+                                new Object[] { s, MetricsConfigurationManager.MP_TIMER_BUCKET_PROP });
+                    }
+                    return null;
+                }
+
+            } else {
+                //either no value.. or too many values through improper syntax
+                continue;
+            }
+
+            sloMinConfiguration = new TimerBucketMinConfiguration(metricName, dur);
+
+            // LIFO - right most configuration takes precedence
+            sloMinConfigCollection.addFirst(sloMinConfiguration);
+        }
+        return sloMinConfigCollection;
+
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
   <properties>
     <version.microprofile-config>3.0.1</version.microprofile-config>
-    <version.microprofile-metrics>5.0.1</version.microprofile-metrics>
+    <version.microprofile-metrics>5.1.0-RC1</version.microprofile-metrics>
 
     <version.micrometer>1.9.3</version.micrometer>
 


### PR DESCRIPTION
Context the new MP Config properties for metrics v5.1 follow the following syntax:
```
<property>=<metric_name>=value[,value2,value3];<metric_name2>=value[,value2,value3]
```
^^ That is to say property is a semi-colon separated _values_ that define the configuration for a specific metric name.

`MericsConfigurationManger` has `getxxx()` which returns an respective sub-class of `PropertyConfiguration` .
For example `getPercentilesConfiguration(...)` returns `MetricPercentileConfiguration`.

This is called as appropriate from the `HistogramAdapter` or `TimerAdapter` during registration as it needs this info to customize the metric.

During the `getxxx()`, it checks if `MericsConfigurationManger` contains an existing _collection of configuration objects_ for the app name that is passed in in its respective `Map<String, Collection<T extends PropertyConfiguration>>`. The collection represents the _configuration_ of the whole property (i.e. all metric names and its associative values). The **appname* that is passed in is used to parse this collection for the specific metric name and value. This is done by calling a static method `matches(Collection<T extends PropertyConfiguration> collection, String metricName)` which accepts a metric name and the collection to go through.

If not, it will  retrieve the MP Config property from the ConfigProvider and add to the respective `Map<String, Collection<T extends PropertyConfiguration>>`.