### PR TITLE
Additional fixes for 5.1.0

### DIFF
--- a/implementation/src/main/java/io/smallrye/metrics/exporters/PrometheusMetricsExporter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/exporters/PrometheusMetricsExporter.java
@@ -190,6 +190,7 @@ public class PrometheusMetricsExporter implements Exporter {
                 set.add("_count");
                 set.add("_sum");
                 set.add("_max");
+                set.add("_bucket");
                 break;
             default:
                 if (LOGGER.isLoggable(Level.FINEST)) {

--- a/implementation/src/main/java/io/smallrye/metrics/setup/config/HistogramBucketMaxConfiguration.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/config/HistogramBucketMaxConfiguration.java
@@ -53,7 +53,10 @@ public class HistogramBucketMaxConfiguration extends PropertySingleValueConfigur
             }
 
             // LIFO - right most configuration takes precedence
-            metricBucketMinMax.addFirst(metricBucketConfiguration);
+            if (metricBucketConfiguration != null) {
+                metricBucketMinMax.addFirst(metricBucketConfiguration);
+            }
+
         }
         return metricBucketMinMax;
 

--- a/implementation/src/main/java/io/smallrye/metrics/setup/config/HistogramBucketMinConfiguration.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/config/HistogramBucketMinConfiguration.java
@@ -53,7 +53,10 @@ public class HistogramBucketMinConfiguration extends PropertySingleValueConfigur
             }
 
             // LIFO - right most configuration takes precedence
-            metricBucketMinMax.addFirst(metricBucketConfiguration);
+            if (metricBucketConfiguration != null) {
+                metricBucketMinMax.addFirst(metricBucketConfiguration);
+            }
+
         }
         return metricBucketMinMax;
 

--- a/implementation/src/main/java/io/smallrye/metrics/setup/config/TimerBucketMaxConfiguration.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/config/TimerBucketMaxConfiguration.java
@@ -69,10 +69,13 @@ public class TimerBucketMaxConfiguration extends PropertySingleValueConfiguratio
                 continue;
             }
 
-            sloMinConfiguration = new TimerBucketMaxConfiguration(metricName, dur);
+            if (dur != null) {
+                sloMinConfiguration = new TimerBucketMaxConfiguration(metricName, dur);
 
-            // LIFO - right most configuration takes precedence
-            sloMinConfigCollection.addFirst(sloMinConfiguration);
+                // LIFO - right most configuration takes precedence
+                sloMinConfigCollection.addFirst(sloMinConfiguration);
+            }
+
         }
         return sloMinConfigCollection;
 

--- a/implementation/src/main/java/io/smallrye/metrics/setup/config/TimerBucketMaxConfiguration.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/config/TimerBucketMaxConfiguration.java
@@ -34,7 +34,7 @@ public class TimerBucketMaxConfiguration extends PropertySingleValueConfiguratio
             String metricName = keyValueSplit[0];
 
             TimerBucketMaxConfiguration sloMinConfiguration = null;
-            Duration dur;
+            Duration dur = null;
             // metricGroup=<blank> == invalid
             if (keyValueSplit.length == 2) {
 

--- a/implementation/src/main/java/io/smallrye/metrics/setup/config/TimerBucketMinConfiguration.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/config/TimerBucketMinConfiguration.java
@@ -69,10 +69,13 @@ public class TimerBucketMinConfiguration extends PropertySingleValueConfiguratio
                 continue;
             }
 
-            sloMinConfiguration = new TimerBucketMinConfiguration(metricName, dur);
+            if (dur != null) {
+                sloMinConfiguration = new TimerBucketMinConfiguration(metricName, dur);
 
-            // LIFO - right most configuration takes precedence
-            sloMinConfigCollection.addFirst(sloMinConfiguration);
+                // LIFO - right most configuration takes precedence
+                sloMinConfigCollection.addFirst(sloMinConfiguration);
+            }
+
         }
         return sloMinConfigCollection;
 

--- a/implementation/src/main/java/io/smallrye/metrics/setup/config/TimerBucketMinConfiguration.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/config/TimerBucketMinConfiguration.java
@@ -34,7 +34,7 @@ public class TimerBucketMinConfiguration extends PropertySingleValueConfiguratio
             String metricName = keyValueSplit[0];
 
             TimerBucketMinConfiguration sloMinConfiguration = null;
-            Duration dur;
+            Duration dur = null;
             // metricGroup=<blank> == invalid
             if (keyValueSplit.length == 2) {
 


### PR DESCRIPTION
- Include "bucket" for generating the suffixed metric names for filtering from micrometer. (For when using the query params to filter out a specific scope and metric name)
- Null checks for Histogram/Timer max/min configuration.