### PR TITLE
- Update to SmallRye Parent 40

### DIFF
--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-~ Copyright 2017 Red Hat, Inc. and/or its affiliates.
+~ Copyright 2017, 2023 Red Hat, Inc. and/or its affiliates.
 ~
 ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 -->
@@ -74,32 +74,20 @@
     </dependency>
 
     <dependency>
-      <groupId>jakarta.json</groupId>
-      <artifactId>jakarta.json-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>jakarta.enterprise</groupId>
       <artifactId>jakarta.enterprise.cdi-api</artifactId>
       <scope>provided</scope>
     </dependency>
-
+    
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.glassfish</groupId>
-      <artifactId>jakarta.json</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/implementation/src/main/java/io/smallrye/metrics/MPPrometheusConfig.java
+++ b/implementation/src/main/java/io/smallrye/metrics/MPPrometheusConfig.java
@@ -5,7 +5,7 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import io.micrometer.prometheus.PrometheusConfig;
 
 /**
- * 
+ *
  * MPPrometheusConfig is an implementation of the {@link PrometheusConfig} which will accept Prometheus
  * related configuration values prepended with "mp.metrics.". This Config is used for the
  * {@link io.micrometer.prometheus.PrometheusMeterRegistry}

--- a/implementation/src/main/java/io/smallrye/metrics/MetricProducer.java
+++ b/implementation/src/main/java/io/smallrye/metrics/MetricProducer.java
@@ -54,7 +54,7 @@ public class MetricProducer {
      * Used to create a MetricProducer with a provided LegacyMetricExtension which
      * would be typically provided by injection as seen above. This constructor is
      * for runtimes that may need to proxy the MetricProducer.
-     * 
+     *
      * @param metricExtension a LegacyMetricsExtension object
      */
     public MetricProducer(LegacyMetricsExtension metricExtension) {

--- a/implementation/src/main/java/io/smallrye/metrics/MetricsRequestHandler.java
+++ b/implementation/src/main/java/io/smallrye/metrics/MetricsRequestHandler.java
@@ -287,7 +287,7 @@ public class MetricsRequestHandler {
 
     /**
      * Check if we can load a class from the Micrometer Prometheus Library
-     * 
+     *
      * @param responder
      * @return true if we were able to load a class from the Micrometer Prometheus library
      * @throws IOException

--- a/implementation/src/main/java/io/smallrye/metrics/SharedMetricRegistries.java
+++ b/implementation/src/main/java/io/smallrye/metrics/SharedMetricRegistries.java
@@ -24,14 +24,14 @@ import io.smallrye.metrics.setup.ApplicationNameResolver;
 /**
  * SharedMetricRegistries is used to create/retrieve a MicroProfile Metric's MetricRegistry instance
  * of a provided scope.
- * 
+ *
  * For each "scope" there exists an individual MicroProfile Metric MetricRegistry which is
  * associated to an single "underlying" Micrometer MeterRegistry that is registered to the Micrometer
  * global registry. This is either a Prometheus MeterRegistry or a "simple" MeterRegistry. By
  * default, it is the Prometheus MeterRegistry unless the MP Config "mp.metrics.prometheus.enabled"
  * is set to false. In which case the simple MeterRegistry is used. Alternatively, if the Prometheus
  * MeterRegistry is not detected on the classpath the simple Meter Registry will be used.
- * 
+ *
  */
 public class SharedMetricRegistries {
 
@@ -93,7 +93,7 @@ public class SharedMetricRegistries {
                     /*
                      * Even if registry is on classpath, needs to have been enabled by config property, otherwise a null
                      * would be returned.
-                     * 
+                     *
                      */
                     if (backendMeterRegistry != null) {
                         Metrics.globalRegistry.add(backendMeterRegistry);
@@ -184,7 +184,7 @@ public class SharedMetricRegistries {
         /*
          * If mp.metrics.prometheus.enabled is explicitly set to false Use SimpleMeterRegistry to associate
          * with MP Metric Registry.
-         * 
+         *
          * Otherwise, attempt to load PrometheusMeterRegistry. If is not on the classpath, then use
          * SimpleMeterRegistry
          */
@@ -274,7 +274,7 @@ public class SharedMetricRegistries {
 
     /**
      * Returns true/false if registry with this scope exists
-     * 
+     *
      * @param scope name of scope
      * @return true/false if registry with this scope exists
      */

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/GaugeAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/GaugeAdapter.java
@@ -112,7 +112,7 @@ interface GaugeAdapter<T extends Number> extends Gauge<T>, MeterHolder {
              * We need to cheat. Micrometer returns a double. The generic parameter R is a
              * Number Or possibly any other boxed Number value. Can't cast to R... Since we
              * already have the object and function... just call it...
-             * 
+             *
              * Also if Gauge is removed from registries and we still have a ref to this (MP)
              * Gauge, we should still be able to retrieve the value instead of querying the
              * meter registry for non-existing gauge.

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/LegacyMetricRegistryAdapter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/LegacyMetricRegistryAdapter.java
@@ -97,7 +97,7 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
 
     /**
      * Associates a metric's MetricID to a specific application if an application name can be resolved.
-     * 
+     *
      * @param metricDescriptor MetricDescriptor of metric
      */
     public void addNameToApplicationMap(MetricDescriptor metricDescriptor) {
@@ -107,7 +107,7 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
 
     /**
      * Associates a metric's MetricID to a specific application if an application name can be resolved.
-     * 
+     *
      * @param MetricID MetricID of metric
      */
     public void addNameToApplicationMap(MetricID MetricID) {
@@ -273,7 +273,7 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
 
     /**
      * Combines metric tags with tag defined for MP config mp.metrics.appname property.
-     * 
+     *
      * @param tags the application tags to be merged with the MP Config mp.metrics.appName tag
      * @return combined Tag array of the MP Config mp.metrics.appName tag with application tags; can return null
      */
@@ -485,7 +485,7 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
      * This is specifically used for runtimes which may need use of a functional counter.
      * For example, the runtime may want to implement a vendor specific counter metric which
      * relies on values obtained from a Mbeans or MXbeans.
-     * 
+     *
      * @param <T> object type
      * @param metadata metadata of metric
      * @param obj object to apply ToDoubleFunction
@@ -959,7 +959,7 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
      * Must be called before any internalGetMetadata calls
      * We may throw an IllegalArgumentException. So we don't
      * want metadata to be registered if it was not necessary.
-     * 
+     *
      * @param tags Tags to be combined with
      * @return tags combined with global tags and mp_app if available
      */
@@ -972,10 +972,10 @@ public class LegacyMetricRegistryAdapter implements MetricRegistry {
                 /*
                  * Need to check if tags being passed in are
                  * 'mp_scope' or 'mp_app'; throw IAE as per spec
-                 * 
+                 *
                  * mp_scope is provided to micrometer registry
                  * during metric/meter registration in the adapters
-                 * 
+                 *
                  * mp_app is resolved with the resolveMPConfigAppNameTag()
                  * logic
                  */

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/LegacyMetricsExtension.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/LegacyMetricsExtension.java
@@ -101,7 +101,7 @@ public class LegacyMetricsExtension implements Extension {
 
     /**
      * Notifies CDI container to check for annotations. This is in place of beans.xml.
-     * 
+     *
      * @param bbd the {@link BeforeBeanDiscovery}
      * @param manager the {@link BeanManager}
      */
@@ -128,7 +128,7 @@ public class LegacyMetricsExtension implements Extension {
      * will not register the producers appropriately. However, interceptors are registered properly.
      * Additionally, MetricProducer injects LegacyMetricsExtension which
      * can not be resolved if this extension class is proxied.
-     * 
+     *
      * @param bbd the {@link BeforeBeanDiscovery}
      * @param manager the {@link BeanManager}
      */

--- a/implementation/src/main/java/io/smallrye/metrics/legacyapi/MetricDescriptor.java
+++ b/implementation/src/main/java/io/smallrye/metrics/legacyapi/MetricDescriptor.java
@@ -76,7 +76,7 @@ class MetricDescriptor {
     /**
      * Checks if this MetricDescriptor's {@link Tags} contain the same tag
      * keys/names as the {@link Tags} provided
-     * 
+     *
      * @param otherTags The other {@link Tags}
      * @return true if the tags key/names match
      */
@@ -89,7 +89,7 @@ class MetricDescriptor {
 
         /*
          * Exactly the same!
-         * 
+         *
          * Don't check if they don't "equal", that will check for values as well, which
          * we don't care about.
          */

--- a/implementation/src/main/java/io/smallrye/metrics/setup/config/MetricPercentileConfiguration.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/config/MetricPercentileConfiguration.java
@@ -26,12 +26,12 @@ public class MetricPercentileConfiguration extends PropertyArrayConfiguration<Do
     }
 
     /**
-     * 
+     *
      * Parse the `mp.metrics.distribution.percentile` property.
      * syntax of {@code <metric_name>=<value-1>,<value-2>,...,<value-n>}
      * No values supplied to a metric name disables percentile output.
      * Can use wild card `*` at the end of metric name (e.g. demo.app.*)
-     * 
+     *
      * @param input MP Config value
      * @return Collection of {@link MetricPercentileConfiguration} objects
      */
@@ -41,7 +41,8 @@ public class MetricPercentileConfiguration extends PropertyArrayConfiguration<Do
         ArrayDeque<MetricPercentileConfiguration> metricPercentileConfigCollection = new ArrayDeque<MetricPercentileConfiguration>();
 
         if (input == null || input.length() == 0) {
-            return null;
+            // no input is the same as disabling all
+            input = "*=";
         }
 
         // not expecting backslashes?

--- a/implementation/src/main/java/io/smallrye/metrics/setup/config/MetricsConfigurationManager.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/config/MetricsConfigurationManager.java
@@ -56,7 +56,7 @@ public class MetricsConfigurationManager {
 
     /**
      * Returns the matching {@link MetricPercentileConfiguration} object if it exists, null otherwise
-     * 
+     *
      * @param metricName the metric name to check configuration against
      * @return the matching {@link MetricPercentileConfiguration} object if it exists, null otherwise
      */
@@ -86,7 +86,7 @@ public class MetricsConfigurationManager {
 
     /**
      * Returns the matching {@link HistogramBucketConfiguration} object if it exists, null otherwise
-     * 
+     *
      * @param metricName the metric name to check configuration against
      * @return the matching {@link HistogramBucketConfiguration} object if it exists, null otherwise
      */
@@ -118,7 +118,7 @@ public class MetricsConfigurationManager {
 
     /**
      * Returns the matching {@link TimerBucketConfiguration} object if it exists, null otherwise
-     * 
+     *
      * @param metricName the metric name to check configuration against
      * @return the matching {@link TimerBucketConfiguration} object if it exists, null otherwise
      */
@@ -148,7 +148,7 @@ public class MetricsConfigurationManager {
 
     /**
      * Returns the matching {@link DefaultBucketConfiguration} object if it exists, null otherwise
-     * 
+     *
      * @param metricName the metric name to check configuration against
      * @return the matching {@link DefaultBucketConfiguration} object if it exists, null otherwise
      */
@@ -179,7 +179,7 @@ public class MetricsConfigurationManager {
 
     /**
      * Returns the matching {@link HistogramBucketMaxConfiguration} object if it exists, null otherwise
-     * 
+     *
      * @param metricName the metric name to check configuration against
      * @return the matching {@link HistogramBucketMaxConfiguration} object if it exists, null otherwise
      */
@@ -212,7 +212,7 @@ public class MetricsConfigurationManager {
 
     /**
      * Returns the matching {@link HistogramBucketMinConfiguration} object if it exists, null otherwise
-     * 
+     *
      * @param metricName the metric name to check configuration against
      * @return the matching {@link HistogramBucketMinConfiguration} object if it exists, null otherwise
      */
@@ -245,7 +245,7 @@ public class MetricsConfigurationManager {
 
     /**
      * Returns the matching {@link TimerBucketMaxConfiguration} object if it exists, null otherwise
-     * 
+     *
      * @param metricName the metric name to check configuration against
      * @return the matching {@link TimerBucketMaxConfiguration} object if it exists, null otherwise
      */
@@ -276,7 +276,7 @@ public class MetricsConfigurationManager {
 
     /**
      * Returns the matching {@link TimerBucketMinConfiguration} object if it exists, null otherwise
-     * 
+     *
      * @param metricName the metric name to check configuration against
      * @return the matching {@link TimerBucketMinConfiguration} object if it exists, null otherwise
      */
@@ -306,7 +306,7 @@ public class MetricsConfigurationManager {
     }
 
     /**
-     * 
+     *
      * @return the application name if it can be resolved, null otherwise
      */
     private String getApplicationName() {
@@ -319,7 +319,7 @@ public class MetricsConfigurationManager {
 
     /**
      * Remove corresponding configurations for an application when that application is unloaded.
-     * 
+     *
      * @param appName the application name
      */
     public synchronized void removeConfiguration(String appName) {

--- a/implementation/src/main/java/io/smallrye/metrics/setup/config/PropertyConfiguration.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/config/PropertyConfiguration.java
@@ -15,7 +15,7 @@ public abstract class PropertyConfiguration {
     /**
      * Given a metric name and a collection of PropertyConfiguration objects, will return a match to the
      * metric name if it exists, otherwise a null is returned.
-     * 
+     *
      * @param <T> extends PropertyConfiguration
      * @param configs Collection of T
      * @param metricName the metric name to find a matching configuration for

--- a/implementation/src/main/java/io/smallrye/metrics/setup/config/TimerBucketConfiguration.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/config/TimerBucketConfiguration.java
@@ -67,6 +67,9 @@ public class TimerBucketConfiguration extends PropertyArrayConfiguration<Duratio
                         return null;
                     }
                 }).filter(s -> s != null).toArray(Duration[]::new);
+
+                Arrays.sort(arrDuration);
+
                 metricBucketConfiguration = new TimerBucketConfiguration(metricName, arrDuration);
             }
 

--- a/implementation/src/main/java/io/smallrye/metrics/setup/config/TimerBucketMaxConfiguration.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/config/TimerBucketMaxConfiguration.java
@@ -53,7 +53,7 @@ public class TimerBucketMaxConfiguration extends PropertySingleValueConfiguratio
                     String val = s.substring(0, s.length() - 1);
                     dur = Duration.ofHours(Long.parseLong(val));
                 } else if (s.matches("[0-9]+")) {
-                    dur = Duration.ofSeconds(Long.parseLong(s));
+                    dur = Duration.ofMillis(Long.parseLong(s));
                 } else {
                     if (LOGGER.isLoggable(Level.FINER)) {
                         LOGGER.logp(Level.FINER, CLASS_NAME, null,
@@ -61,7 +61,6 @@ public class TimerBucketMaxConfiguration extends PropertySingleValueConfiguratio
                                         + "optional time unit (e.g. ms,s,m,h) are accepted.",
                                 new Object[] { s, MetricsConfigurationManager.MP_TIMER_BUCKET_PROP });
                     }
-                    return null;
                 }
 
             } else {

--- a/implementation/src/main/java/io/smallrye/metrics/setup/config/TimerBucketMinConfiguration.java
+++ b/implementation/src/main/java/io/smallrye/metrics/setup/config/TimerBucketMinConfiguration.java
@@ -53,7 +53,7 @@ public class TimerBucketMinConfiguration extends PropertySingleValueConfiguratio
                     String val = s.substring(0, s.length() - 1);
                     dur = Duration.ofHours(Long.parseLong(val));
                 } else if (s.matches("[0-9]+")) {
-                    dur = Duration.ofSeconds(Long.parseLong(s));
+                    dur = Duration.ofMillis(Long.parseLong(s));
                 } else {
                     if (LOGGER.isLoggable(Level.FINER)) {
                         LOGGER.logp(Level.FINER, CLASS_NAME, null,
@@ -61,7 +61,6 @@ public class TimerBucketMinConfiguration extends PropertySingleValueConfiguratio
                                         + "optional time unit (e.g. ms,s,m,h) are accepted.",
                                 new Object[] { s, MetricsConfigurationManager.MP_TIMER_BUCKET_PROP });
                     }
-                    return null;
                 }
 
             } else {

--- a/implementation/src/test/java/io/smallrye/metrics/MediaHandlerTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/MediaHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, 2022 Red Hat, Inc. and/or its affiliates
+ * Copyright 2018, 2023 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,8 +21,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author hrupp
@@ -31,7 +31,7 @@ public class MediaHandlerTest {
 
     MetricsRequestHandler requestHandler;
 
-    @Before
+    @BeforeEach
     public void setUp() {
 
         requestHandler = new MetricsRequestHandler();
@@ -43,6 +43,7 @@ public class MediaHandlerTest {
                 .getBestMatchingMediaType(Stream.of("application/json;q=0.1", "text/plain;q=0.9"));
         assertThat(res.isPresent()).isTrue();
         assertThat(res.get()).isEqualTo("text/plain");
+
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/metrics/MetricRegistryThreadSafetyTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/MetricRegistryThreadSafetyTest.java
@@ -17,8 +17,7 @@
 
 package io.smallrye.metrics;
 
-import static org.junit.Assert.assertEquals;
-
+// import static org.junit.Assert.assertEquals;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -33,16 +32,16 @@ import org.eclipse.microprofile.metrics.MetricFilter;
 import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.Tag;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class MetricRegistryThreadSafetyTest {
 
     private final MetricRegistry registry = SharedMetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
 
-    @After
+    @AfterEach
     public void cleanup() {
         registry.removeMatching(MetricFilter.ALL);
     }
@@ -78,8 +77,8 @@ public class MetricRegistryThreadSafetyTest {
             executor.shutdown();
             executor.awaitTermination(10, TimeUnit.SECONDS);
 
-            assertEquals("All threads should finish without exceptions",
-                    0, Arrays.stream(futures).filter(CompletableFuture::isCompletedExceptionally).count());
+            Assertions.assertEquals(0, Arrays.stream(futures).filter(CompletableFuture::isCompletedExceptionally).count(),
+                    "All threads should finish without exceptions");
         }
     }
 
@@ -88,7 +87,7 @@ public class MetricRegistryThreadSafetyTest {
      * at the same time.
      */
     @Test
-    @Ignore // FIXME, fails
+    @Disabled // FIXME, fails
     public void registerAndGetMetadata() throws InterruptedException, ExecutionException, TimeoutException {
         final AtomicReference<Throwable> throwableEncounteredDuringTest = new AtomicReference<>();
         ExecutorService executor = Executors.newFixedThreadPool(50);
@@ -118,9 +117,10 @@ public class MetricRegistryThreadSafetyTest {
             CompletableFuture.allOf(futures).get(30, TimeUnit.SECONDS);
 
             // assert that no task received an error and that the registry contains all required data
-            Assert.assertNull(throwableEncounteredDuringTest.get());
-            Assert.assertEquals(1000, registry.getMetadata().size());
-            Assert.assertEquals(1000, registry.getCounters().size());
+            Assertions.assertNull(throwableEncounteredDuringTest.get());
+            Assertions.assertEquals(1000, registry.getMetadata().size());
+            Assertions.assertEquals(1000, 1000, registry.getCounters().size());
+
         } finally {
             executor.shutdown();
             executor.awaitTermination(10, TimeUnit.SECONDS);

--- a/implementation/src/test/java/io/smallrye/metrics/configuration/DefaultBucketTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/configuration/DefaultBucketTest.java
@@ -87,8 +87,6 @@ public class DefaultBucketTest {
 
     /*
      * Test Histogram min and max.
-     *
-     *
      */
     @Test
     public void testHistogramBucketMaxMinGoodConfig() {
@@ -212,7 +210,6 @@ public class DefaultBucketTest {
 
     /*
      * Test Timer min and max.
-     *
      */
     @Test
     public void testTimerBucketMaxMinGoodConfig() {

--- a/implementation/src/test/java/io/smallrye/metrics/configuration/DefaultBucketTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/configuration/DefaultBucketTest.java
@@ -1,0 +1,337 @@
+package io.smallrye.metrics.configuration;
+
+import java.time.Duration;
+import java.util.Collection;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.metrics.setup.config.DefaultBucketConfiguration;
+import io.smallrye.metrics.setup.config.HistogramBucketMaxConfiguration;
+import io.smallrye.metrics.setup.config.HistogramBucketMinConfiguration;
+import io.smallrye.metrics.setup.config.TimerBucketMaxConfiguration;
+import io.smallrye.metrics.setup.config.TimerBucketMinConfiguration;
+
+public class DefaultBucketTest {
+
+    @Test
+    public void testGoodConfiguration() {
+        String input = "test.metric1=true;test.metric2=false";
+
+        Collection<DefaultBucketConfiguration> collection = DefaultBucketConfiguration.parse(input);
+
+        DefaultBucketConfiguration dbc = DefaultBucketConfiguration.matches(collection, "test.metric1");
+        Assertions.assertEquals(dbc.getMetricNameGrouping(), "test.metric1");
+        Assertions.assertEquals(dbc.isEnabled(), true);
+
+        dbc = DefaultBucketConfiguration.matches(collection, "test.metric2");
+        Assertions.assertEquals(dbc.getMetricNameGrouping(), "test.metric2");
+        Assertions.assertEquals(dbc.isEnabled(), false);
+
+    }
+
+    @Test
+    public void testNonExistentConfiguration() {
+        String input = "test.metric1=true;test.metric2=false";
+
+        Collection<DefaultBucketConfiguration> collection = DefaultBucketConfiguration.parse(input);
+
+        DefaultBucketConfiguration dbc = DefaultBucketConfiguration.matches(collection, "test.metric3");
+        Assertions.assertNull(dbc);
+
+    }
+
+    @Test
+    public void testOverride1() {
+        String input = "test.*=false;test.metric1=true";
+
+        Collection<DefaultBucketConfiguration> collection = DefaultBucketConfiguration.parse(input);
+
+        DefaultBucketConfiguration dbc = DefaultBucketConfiguration.matches(collection, "test.metric1");
+        Assertions.assertEquals(dbc.getMetricNameGrouping(), "test.metric1");
+        Assertions.assertEquals(dbc.isEnabled(), true);
+
+        dbc = DefaultBucketConfiguration.matches(collection, "test.metric2");
+        Assertions.assertEquals(dbc.getMetricNameGrouping(), "test.*");
+        Assertions.assertEquals(dbc.isEnabled(), false);
+
+    }
+
+    @Test
+    public void testOverride2() {
+        String input = "test.metric1=true;test.*=false";
+
+        Collection<DefaultBucketConfiguration> collection = DefaultBucketConfiguration.parse(input);
+
+        DefaultBucketConfiguration dbc = DefaultBucketConfiguration.matches(collection, "test.metric1");
+        Assertions.assertEquals(dbc.getMetricNameGrouping(), "test.*");
+        Assertions.assertEquals(dbc.isEnabled(), false);
+
+        dbc = DefaultBucketConfiguration.matches(collection, "test.metric2");
+        Assertions.assertEquals(dbc.getMetricNameGrouping(), "test.*");
+        Assertions.assertEquals(dbc.isEnabled(), false);
+
+    }
+
+    @Test
+    public void testBadValue1() {
+        String input = "test.metric1=sdf";
+
+        Collection<DefaultBucketConfiguration> collection = DefaultBucketConfiguration.parse(input);
+
+        DefaultBucketConfiguration dbc = DefaultBucketConfiguration.matches(collection, "test.metric1");
+        Assertions.assertEquals(dbc.getMetricNameGrouping(), "test.metric1");
+        Assertions.assertEquals(dbc.isEnabled(), false);
+
+    }
+
+    /*
+     * Test Histogram min and max.
+     *
+     *
+     */
+    @Test
+    public void testHistogramBucketMaxMinGoodConfig() {
+        String input = "test.metric1=23;test.metric2=45";
+
+        /*
+         * MAX
+         */
+        Collection<HistogramBucketMaxConfiguration> collectionMax = HistogramBucketMaxConfiguration.parse(input);
+
+        HistogramBucketMaxConfiguration hbmaxc = HistogramBucketMaxConfiguration.matches(collectionMax, "test.metric1");
+        Assertions.assertEquals(hbmaxc.getMetricNameGrouping(), "test.metric1");
+        Assertions.assertEquals(hbmaxc.getValue(), 23.0);
+
+        hbmaxc = HistogramBucketMaxConfiguration.matches(collectionMax, "test.metric2");
+        Assertions.assertEquals(hbmaxc.getMetricNameGrouping(), "test.metric2");
+        Assertions.assertEquals(hbmaxc.getValue(), 45.0);
+
+        /*
+         * MIN
+         */
+        Collection<HistogramBucketMinConfiguration> collectionMin = HistogramBucketMinConfiguration.parse(input);
+
+        HistogramBucketMinConfiguration hbmincc = HistogramBucketMinConfiguration.matches(collectionMin, "test.metric1");
+        Assertions.assertEquals(hbmincc.getMetricNameGrouping(), "test.metric1");
+        Assertions.assertEquals(hbmincc.getValue(), 23.0);
+
+        hbmincc = HistogramBucketMinConfiguration.matches(collectionMin, "test.metric2");
+        Assertions.assertEquals(hbmincc.getMetricNameGrouping(), "test.metric2");
+        Assertions.assertEquals(hbmincc.getValue(), 45.0);
+
+    }
+
+    @Test
+    public void testHistogramBucketMaxMinNonExistentConfig() {
+        String input = "test.metric1=23;test.metric2=45";
+
+        /*
+         * MAX
+         */
+        Collection<HistogramBucketMaxConfiguration> collectionMax = HistogramBucketMaxConfiguration.parse(input);
+
+        HistogramBucketMaxConfiguration hbmaxc = HistogramBucketMaxConfiguration.matches(collectionMax, "test.metric3");
+        Assertions.assertNull(hbmaxc);
+
+        /*
+         * MIN
+         */
+        Collection<HistogramBucketMinConfiguration> collectionMin = HistogramBucketMinConfiguration.parse(input);
+
+        HistogramBucketMinConfiguration hbmincc = HistogramBucketMinConfiguration.matches(collectionMin, "test.metric3");
+        Assertions.assertNull(hbmincc);
+
+    }
+
+    @Test
+    public void testHistogramBucketMaxMinOverride() {
+        String input = "test.metric1=34.0;test.*=23;test.metric2=45";
+
+        /*
+         * MAX
+         */
+        Collection<HistogramBucketMaxConfiguration> collectionMax = HistogramBucketMaxConfiguration.parse(input);
+
+        HistogramBucketMaxConfiguration hbmaxc = HistogramBucketMaxConfiguration.matches(collectionMax, "test.metric1");
+        Assertions.assertEquals(hbmaxc.getMetricNameGrouping(), "test.*");
+        Assertions.assertEquals(hbmaxc.getValue(), 23.0);
+
+        hbmaxc = HistogramBucketMaxConfiguration.matches(collectionMax, "test.metric2");
+        Assertions.assertEquals(hbmaxc.getMetricNameGrouping(), "test.metric2");
+        Assertions.assertEquals(hbmaxc.getValue(), 45.0);
+
+        /*
+         * MIN
+         */
+        Collection<HistogramBucketMinConfiguration> collectionMin = HistogramBucketMinConfiguration.parse(input);
+
+        HistogramBucketMinConfiguration hbmincc = HistogramBucketMinConfiguration.matches(collectionMin, "test.metric1");
+        Assertions.assertEquals(hbmincc.getMetricNameGrouping(), "test.*");
+        Assertions.assertEquals(hbmincc.getValue(), 23.0);
+
+        hbmincc = HistogramBucketMinConfiguration.matches(collectionMin, "test.metric2");
+        Assertions.assertEquals(hbmincc.getMetricNameGrouping(), "test.metric2");
+        Assertions.assertEquals(hbmincc.getValue(), 45.0);
+
+    }
+
+    @Test
+    public void testHistogramBucketMaxMinBadConfig() {
+
+        /*
+         * test.metric1 -> not valid, does not accept any of the values
+         * test.metric2 -> not valid
+         */
+        String input = "test.metric1=34.0,23;test.metric2=abc";
+
+        /*
+         * MAX
+         */
+        Collection<HistogramBucketMaxConfiguration> collectionMax = HistogramBucketMaxConfiguration.parse(input);
+
+        HistogramBucketMaxConfiguration hbmaxc = HistogramBucketMaxConfiguration.matches(collectionMax, "test.metric1");
+        Assertions.assertNull(hbmaxc);
+
+        hbmaxc = HistogramBucketMaxConfiguration.matches(collectionMax, "test.metric2");
+        Assertions.assertNull(hbmaxc);
+
+        /*
+         * MIN
+         */
+        Collection<HistogramBucketMinConfiguration> collectionMin = HistogramBucketMinConfiguration.parse(input);
+
+        HistogramBucketMinConfiguration hbmincc = HistogramBucketMinConfiguration.matches(collectionMin,
+                "test.metric1");
+        Assertions.assertNull(hbmincc);
+
+        hbmincc = HistogramBucketMinConfiguration.matches(collectionMin, "test.metric2");
+        Assertions.assertNull(hbmincc);
+
+    }
+
+    /*
+     * Test Timer min and max.
+     *
+     */
+    @Test
+    public void testTimerBucketMaxMinGoodConfig() {
+        String input = "test.metric1=23;test.metric2=45";
+
+        /*
+         * MAX
+         */
+        Collection<TimerBucketMaxConfiguration> collectionMax = TimerBucketMaxConfiguration.parse(input);
+
+        TimerBucketMaxConfiguration tbmaxc = TimerBucketMaxConfiguration.matches(collectionMax, "test.metric1");
+        Assertions.assertEquals(tbmaxc.getMetricNameGrouping(), "test.metric1");
+        Assertions.assertEquals(tbmaxc.getValue(), Duration.ofMillis(23));
+
+        tbmaxc = TimerBucketMaxConfiguration.matches(collectionMax, "test.metric2");
+        Assertions.assertEquals(tbmaxc.getMetricNameGrouping(), "test.metric2");
+        Assertions.assertEquals(tbmaxc.getValue(), Duration.ofMillis(45));
+
+        /*
+         * MIN
+         */
+        Collection<TimerBucketMinConfiguration> collectionMin = TimerBucketMinConfiguration.parse(input);
+
+        TimerBucketMinConfiguration tbmincc = TimerBucketMinConfiguration.matches(collectionMin, "test.metric1");
+        Assertions.assertEquals(tbmincc.getMetricNameGrouping(), "test.metric1");
+        Assertions.assertEquals(tbmincc.getValue(), Duration.ofMillis(23));
+
+        tbmincc = TimerBucketMinConfiguration.matches(collectionMin, "test.metric2");
+        Assertions.assertEquals(tbmincc.getMetricNameGrouping(), "test.metric2");
+        Assertions.assertEquals(tbmincc.getValue(), Duration.ofMillis(45));
+
+    }
+
+    @Test
+    public void testTimerBucketMaxMinNonExistentConfig() {
+        String input = "test.metric1=23;test.metric2=45";
+
+        /*
+         * MAX
+         */
+        Collection<TimerBucketMaxConfiguration> collectionMax = TimerBucketMaxConfiguration.parse(input);
+
+        TimerBucketMaxConfiguration tbmaxc = TimerBucketMaxConfiguration.matches(collectionMax, "test.metric3");
+        Assertions.assertNull(tbmaxc);
+
+        /*
+         * MIN
+         */
+        Collection<TimerBucketMinConfiguration> collectionMin = TimerBucketMinConfiguration.parse(input);
+
+        TimerBucketMinConfiguration tbmincc = TimerBucketMinConfiguration.matches(collectionMin, "test.metric3");
+        Assertions.assertNull(tbmincc);
+
+    }
+
+    @Test
+    public void testTimerBucketMaxMinOverride() {
+        String input = "test.metric1=34ms;test.*=23;test.metric2=45s";
+
+        /*
+         * MAX
+         */
+        Collection<TimerBucketMaxConfiguration> collectionMax = TimerBucketMaxConfiguration.parse(input);
+
+        TimerBucketMaxConfiguration tbmaxc = TimerBucketMaxConfiguration.matches(collectionMax, "test.metric1");
+        Assertions.assertEquals(tbmaxc.getMetricNameGrouping(), "test.*");
+
+        Assertions.assertEquals(tbmaxc.getValue(), Duration.ofMillis(23));
+
+        tbmaxc = TimerBucketMaxConfiguration.matches(collectionMax, "test.metric2");
+        Assertions.assertEquals(tbmaxc.getMetricNameGrouping(), "test.metric2");
+        Assertions.assertEquals(tbmaxc.getValue(), Duration.ofSeconds(45));
+
+        /*
+         * MIN
+         */
+        Collection<TimerBucketMinConfiguration> collectionMin = TimerBucketMinConfiguration.parse(input);
+
+        TimerBucketMinConfiguration tbmincc = TimerBucketMinConfiguration.matches(collectionMin, "test.metric1");
+        Assertions.assertEquals(tbmincc.getMetricNameGrouping(), "test.*");
+        Assertions.assertEquals(tbmincc.getValue(), Duration.ofMillis(23));
+
+        tbmincc = TimerBucketMinConfiguration.matches(collectionMin, "test.metric2");
+        Assertions.assertEquals(tbmincc.getMetricNameGrouping(), "test.metric2");
+        Assertions.assertEquals(tbmincc.getValue(), Duration.ofSeconds(45));
+
+    }
+
+    @Test
+    public void testTimerBucketMaxMinBadConfig() {
+
+        /*
+         * test.metric1 -> not valid, does not accept any of the values
+         * test.metric2 -> not valid
+         */
+        String input = "test.metric1=34s,23ms;test.metric2=abc";
+
+        /*
+         * MAX
+         */
+        Collection<TimerBucketMaxConfiguration> collectionMax = TimerBucketMaxConfiguration.parse(input);
+
+        TimerBucketMaxConfiguration tbmaxc = TimerBucketMaxConfiguration.matches(collectionMax, "test.metric1");
+        Assertions.assertNull(tbmaxc);
+
+        tbmaxc = TimerBucketMaxConfiguration.matches(collectionMax, "test.metric2");
+        Assertions.assertNull(tbmaxc);
+
+        /*
+         * MIN
+         */
+        Collection<TimerBucketMinConfiguration> collectionMin = TimerBucketMinConfiguration.parse(input);
+
+        TimerBucketMinConfiguration tbmincc = TimerBucketMinConfiguration.matches(collectionMin,
+                "test.metric1");
+        Assertions.assertNull(tbmincc);
+
+        tbmincc = TimerBucketMinConfiguration.matches(collectionMin, "test.metric2");
+        Assertions.assertNull(tbmincc);
+
+    }
+}

--- a/implementation/src/test/java/io/smallrye/metrics/configuration/HistogramConfigurationTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/configuration/HistogramConfigurationTest.java
@@ -1,0 +1,124 @@
+package io.smallrye.metrics.configuration;
+
+import java.util.Collection;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.metrics.setup.config.HistogramBucketConfiguration;
+
+public class HistogramConfigurationTest {
+
+    @Test
+    public void testGoodConfiguration() {
+        String input = "test.metric1=0.2,0.45,123,345,678,1239;metric2=123,56,0.96";
+
+        Collection<HistogramBucketConfiguration> collection = HistogramBucketConfiguration.parse(input);
+
+        HistogramBucketConfiguration hbc = HistogramBucketConfiguration.matches(collection, "test.metric1");
+        Assertions.assertEquals(hbc.getMetricNameGrouping(), "test.metric1");
+        Assertions.assertArrayEquals(hbc.getValues(), new Double[] { 0.2, 0.45, 123.0, 345.0, 678.0, 1239.0 });
+
+        hbc = HistogramBucketConfiguration.matches(collection, "metric2");
+        Assertions.assertEquals(hbc.getMetricNameGrouping(), "metric2");
+        Assertions.assertArrayEquals(hbc.getValues(), new Double[] { 0.96, 56.0, 123.0 });
+
+    }
+
+    @Test
+    public void testNonExistentValue() {
+        String input = "test.metric1=0.2,0.45,123,345,678,1239;metric2=123,56,0.96";
+
+        Collection<HistogramBucketConfiguration> collection = HistogramBucketConfiguration.parse(input);
+
+        HistogramBucketConfiguration hbc = HistogramBucketConfiguration.matches(collection, "test.metric9");
+        Assertions.assertNull(hbc);
+
+    }
+
+    @Test
+    public void testOverride1() {
+        String input = "test.metric1=1,6,9;test.metric2=0.2,45,99;test.sub.metric=1;*=12,34,56";
+
+        Collection<HistogramBucketConfiguration> collection = HistogramBucketConfiguration.parse(input);
+
+        HistogramBucketConfiguration hbc = HistogramBucketConfiguration.matches(collection, "test.metric1");
+        Assertions.assertEquals(hbc.getMetricNameGrouping(), "*");
+        Assertions.assertArrayEquals(hbc.getValues(), new Double[] { 12.0, 34.0, 56.0 });
+
+        hbc = HistogramBucketConfiguration.matches(collection, "test.metric2");
+        Assertions.assertEquals(hbc.getMetricNameGrouping(), "*");
+        Assertions.assertArrayEquals(hbc.getValues(), new Double[] { 12.0, 34.0, 56.0 });
+
+        hbc = HistogramBucketConfiguration.matches(collection, "test.sub.metric");
+        Assertions.assertEquals(hbc.getMetricNameGrouping(), "*");
+        Assertions.assertArrayEquals(hbc.getValues(), new Double[] { 12.0, 34.0, 56.0 });
+
+        hbc = HistogramBucketConfiguration.matches(collection, "any.value");
+        Assertions.assertEquals(hbc.getMetricNameGrouping(), "*");
+        Assertions.assertArrayEquals(hbc.getValues(), new Double[] { 12.0, 34.0, 56.0 });
+
+    }
+
+    @Test
+    public void testOverride2() {
+        String input = "*=12,34,56;test.metric1=1,6,9;test.metric2=0.2,45,99;test.sub.metric=1";
+
+        Collection<HistogramBucketConfiguration> collection = HistogramBucketConfiguration.parse(input);
+
+        HistogramBucketConfiguration hbc = HistogramBucketConfiguration.matches(collection, "test.metric1");
+        Assertions.assertEquals(hbc.getMetricNameGrouping(), "test.metric1");
+        Assertions.assertArrayEquals(hbc.getValues(), new Double[] { 1.0, 6.0, 9.0 });
+
+        hbc = HistogramBucketConfiguration.matches(collection, "test.metric2");
+        Assertions.assertEquals(hbc.getMetricNameGrouping(), "test.metric2");
+        Assertions.assertArrayEquals(hbc.getValues(), new Double[] { 0.2, 45.0, 99.0 });
+
+        hbc = HistogramBucketConfiguration.matches(collection, "test.sub.metric");
+        Assertions.assertEquals(hbc.getMetricNameGrouping(), "test.sub.metric");
+        Assertions.assertArrayEquals(hbc.getValues(), new Double[] { 1.0 });
+
+        hbc = HistogramBucketConfiguration.matches(collection, "any.value");
+        Assertions.assertEquals(hbc.getMetricNameGrouping(), "*");
+        Assertions.assertArrayEquals(hbc.getValues(), new Double[] { 12.0, 34.0, 56.0 });
+
+    }
+
+    @Test
+    public void testBadValue1() {
+
+        /*
+         * test.metric1 has valid 0.5, 33.0, 34.0
+         * test.metric2 has no valid values
+         */
+        String input = "test.metric1=12s,234m,-0.2,0.5,34,e3,43f,33;test.metric2=345s,dg,#$G#$,#*(45";
+
+        Collection<HistogramBucketConfiguration> collection = HistogramBucketConfiguration.parse(input);
+
+        HistogramBucketConfiguration hbc = HistogramBucketConfiguration.matches(collection, "test.metric1");
+        Assertions.assertEquals(hbc.getMetricNameGrouping(), "test.metric1");
+        Assertions.assertArrayEquals(hbc.getValues(), new Double[] { 0.5, 33.0, 34.0 });
+
+        hbc = HistogramBucketConfiguration.matches(collection, "test.metric2");
+        Assertions.assertEquals(hbc.getMetricNameGrouping(), "test.metric2");
+        Assertions.assertArrayEquals(hbc.getValues(), new Double[] {});
+
+    }
+
+    @Test
+    public void testBadValue2() {
+        String input = "test.metric1=34,test.metric2=34;test.metric3;test.metric2=";
+
+        Collection<HistogramBucketConfiguration> collection = HistogramBucketConfiguration.parse(input);
+
+        HistogramBucketConfiguration hbc = HistogramBucketConfiguration.matches(collection, "test.metric1");
+        Assertions.assertEquals(hbc.getMetricNameGrouping(), "test.metric1");
+        Assertions.assertArrayEquals(hbc.getValues(), new Double[] { 34.0 });
+
+        hbc = HistogramBucketConfiguration.matches(collection, "test.metric2");
+        Assertions.assertNull(hbc);
+
+        hbc = HistogramBucketConfiguration.matches(collection, "test.metric3");
+        Assertions.assertNull(hbc);
+    }
+}

--- a/implementation/src/test/java/io/smallrye/metrics/configuration/PercentileConfigurationTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/configuration/PercentileConfigurationTest.java
@@ -1,0 +1,211 @@
+package io.smallrye.metrics.configuration;
+
+import java.util.Collection;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.metrics.setup.config.MetricPercentileConfiguration;
+import io.smallrye.metrics.setup.config.PropertyConfiguration;
+
+public class PercentileConfigurationTest {
+
+    @Test
+    public void testGoodValues() {
+
+        String input = "test.metric1=0.3,0.5,0.9;test.metric2=0.09,0.4,0.8,0.3";
+
+        Collection<MetricPercentileConfiguration> collection = MetricPercentileConfiguration
+                .parseMetricPercentiles(input);
+
+        MetricPercentileConfiguration mpc = PropertyConfiguration.matches(collection, "test.metric1");
+        Assertions.assertEquals(mpc.getMetricNameGrouping(), "test.metric1");
+        Assertions.assertArrayEquals(mpc.getValues(), new Double[] { 0.3, 0.5, 0.9 });
+
+        mpc = PropertyConfiguration.matches(collection, "test.metric2");
+        Assertions.assertEquals(mpc.getMetricNameGrouping(), "test.metric2");
+        Assertions.assertArrayEquals(mpc.getValues(), new Double[] { 0.09, 0.3, 0.4, 0.8 });
+
+    }
+
+    @Test
+    public void testNonExistingValue() {
+
+        String input = "test.metric1=0.3,0.5,0.9;test.metric2=0.09,0.4,0.8,0.3";
+
+        Collection<MetricPercentileConfiguration> collection = MetricPercentileConfiguration
+                .parseMetricPercentiles(input);
+
+        MetricPercentileConfiguration mpc = PropertyConfiguration.matches(collection, "test.metric99");
+        Assertions.assertNull(mpc);
+    }
+
+    @Test
+    public void testOverride1() {
+
+        String input = "test.*=0.5,0.6,0.99;test.metric1=0.1,0.2;test.metric2=0.3;test.metric.metric1=0.8";
+        Collection<MetricPercentileConfiguration> collection = MetricPercentileConfiguration
+                .parseMetricPercentiles(input);
+
+        MetricPercentileConfiguration mpc = PropertyConfiguration.matches(collection, "test.metric1");
+        Assertions.assertEquals(mpc.getMetricNameGrouping(), "test.metric1");
+        Assertions.assertArrayEquals(mpc.getValues(), new Double[] { 0.1, 0.2 });
+
+        mpc = PropertyConfiguration.matches(collection, "test.metric2");
+        Assertions.assertEquals(mpc.getMetricNameGrouping(), "test.metric2");
+        Assertions.assertArrayEquals(mpc.getValues(), new Double[] { 0.3 });
+
+        mpc = PropertyConfiguration.matches(collection, "test.metric3");
+        Assertions.assertEquals(mpc.getMetricNameGrouping(), "test.*");
+        Assertions.assertArrayEquals(mpc.getValues(), new Double[] { 0.5, 0.6, 0.99 });
+
+        mpc = PropertyConfiguration.matches(collection, "test.test.metric");
+        Assertions.assertEquals(mpc.getMetricNameGrouping(), "test.*");
+        Assertions.assertArrayEquals(mpc.getValues(), new Double[] { 0.5, 0.6, 0.99 });
+
+        mpc = PropertyConfiguration.matches(collection, "test.test.sub.metric");
+        Assertions.assertEquals(mpc.getMetricNameGrouping(), "test.*");
+        Assertions.assertArrayEquals(mpc.getValues(), new Double[] { 0.5, 0.6, 0.99 });
+
+        mpc = PropertyConfiguration.matches(collection, "test.metric.metric1");
+        Assertions.assertEquals(mpc.getMetricNameGrouping(), "test.metric.metric1");
+        Assertions.assertArrayEquals(mpc.getValues(), new Double[] { 0.8 });
+
+    }
+
+    @Test
+    public void testOverride2() {
+
+        String input = "test.metric1=0.1,0.2;test.metric2=0.3;test.metric.metric1=0.8;test.*=0.5,0.6,0.99";
+        Collection<MetricPercentileConfiguration> collection = MetricPercentileConfiguration
+                .parseMetricPercentiles(input);
+
+        MetricPercentileConfiguration mpc = PropertyConfiguration.matches(collection, "test.metric1");
+        Assertions.assertEquals(mpc.getMetricNameGrouping(), "test.*");
+        Assertions.assertArrayEquals(mpc.getValues(), new Double[] { 0.5, 0.6, 0.99 });
+
+        mpc = PropertyConfiguration.matches(collection, "test.metric2");
+        Assertions.assertEquals(mpc.getMetricNameGrouping(), "test.*");
+        Assertions.assertArrayEquals(mpc.getValues(), new Double[] { 0.5, 0.6, 0.99 });
+
+        mpc = PropertyConfiguration.matches(collection, "test.metric3");
+        Assertions.assertEquals(mpc.getMetricNameGrouping(), "test.*");
+        Assertions.assertArrayEquals(mpc.getValues(), new Double[] { 0.5, 0.6, 0.99 });
+
+        mpc = PropertyConfiguration.matches(collection, "test.test.metric");
+        Assertions.assertEquals(mpc.getMetricNameGrouping(), "test.*");
+        Assertions.assertArrayEquals(mpc.getValues(), new Double[] { 0.5, 0.6, 0.99 });
+
+        mpc = PropertyConfiguration.matches(collection, "test.metric.metric1");
+        Assertions.assertEquals(mpc.getMetricNameGrouping(), "test.*");
+        Assertions.assertArrayEquals(mpc.getValues(), new Double[] { 0.5, 0.6, 0.99 });
+
+    }
+
+    @Test
+    public void testDisable() {
+
+        String input = "test.metric1=";
+        Collection<MetricPercentileConfiguration> collection = MetricPercentileConfiguration
+                .parseMetricPercentiles(input);
+
+        MetricPercentileConfiguration mpc = PropertyConfiguration.matches(collection, "test.metric1");
+
+        Assertions.assertEquals(mpc.getMetricNameGrouping(), "test.metric1");
+        Assertions.assertTrue(mpc.isDisabled());
+        Assertions.assertNull(mpc.getValues());
+
+    }
+
+    @Test
+    public void testDisableWildcard1() {
+
+        String input = "test.*";
+        Collection<MetricPercentileConfiguration> collection = MetricPercentileConfiguration
+                .parseMetricPercentiles(input);
+
+        MetricPercentileConfiguration mpc = PropertyConfiguration.matches(collection, "test.metric1");
+
+        Assertions.assertEquals(mpc.getMetricNameGrouping(), "test.*");
+        Assertions.assertTrue(mpc.isDisabled());
+        Assertions.assertNull(mpc.getValues());
+
+    }
+
+    @Test
+    public void testDisableWildcard2() {
+
+        String input = "*=";
+        Collection<MetricPercentileConfiguration> collection = MetricPercentileConfiguration
+                .parseMetricPercentiles(input);
+
+        MetricPercentileConfiguration mpc = PropertyConfiguration.matches(collection, "test.metric1");
+
+        Assertions.assertEquals(mpc.getMetricNameGrouping(), "*");
+        Assertions.assertTrue(mpc.isDisabled());
+        Assertions.assertNull(mpc.getValues());
+
+    }
+
+    @Test
+    public void testDisableAll() {
+
+        String input = "";
+        Collection<MetricPercentileConfiguration> collection = MetricPercentileConfiguration
+                .parseMetricPercentiles(input);
+
+        MetricPercentileConfiguration mpc = PropertyConfiguration.matches(collection, "test.metric1");
+
+        Assertions.assertEquals(mpc.getMetricNameGrouping(), "*");
+        Assertions.assertTrue(mpc.isDisabled());
+        Assertions.assertNull(mpc.getValues());
+
+    }
+
+    @Test
+    public void testBadValue1() {
+
+        /*
+         * metric1 has a valid 0.2
+         * metric2 has no valid values
+         * metric3 has a valid 0.5
+         */
+        String input = "metric1=23,0.2,34*(;metric2=89,34,#$,fj;metric3=1.3,2.4,0.5;metric4=sdf,$%,0..0,0.8,0,,0.9";
+        Collection<MetricPercentileConfiguration> collection = MetricPercentileConfiguration
+                .parseMetricPercentiles(input);
+
+        MetricPercentileConfiguration mpc = PropertyConfiguration.matches(collection, "metric1");
+        Assertions.assertEquals(mpc.getMetricNameGrouping(), "metric1");
+        Assertions.assertArrayEquals(mpc.getValues(), new Double[] { 0.2 });
+
+        mpc = PropertyConfiguration.matches(collection, "metric2");
+        Assertions.assertEquals(mpc.getMetricNameGrouping(), "metric2");
+        Assertions.assertArrayEquals(mpc.getValues(), new Double[] {});
+
+        mpc = PropertyConfiguration.matches(collection, "metric3");
+        Assertions.assertEquals(mpc.getMetricNameGrouping(), "metric3");
+        Assertions.assertArrayEquals(mpc.getValues(), new Double[] { 0.5 });
+
+        mpc = PropertyConfiguration.matches(collection, "metric4");
+        Assertions.assertEquals(mpc.getMetricNameGrouping(), "metric4");
+        Assertions.assertArrayEquals(mpc.getValues(), new Double[] { 0.8, 0.9 });
+    }
+
+    @Test
+    public void testBadValue2() {
+
+        /*
+         * metric1 has a valid 0.2
+         * `*` overrides. No valid values for anything.
+         */
+        String input = "metric1=23,0.2,34*(;*=90.3,fs,)*";
+        Collection<MetricPercentileConfiguration> collection = MetricPercentileConfiguration
+                .parseMetricPercentiles(input);
+
+        MetricPercentileConfiguration mpc = PropertyConfiguration.matches(collection, "metric1");
+        Assertions.assertEquals(mpc.getMetricNameGrouping(), "*");
+        Assertions.assertArrayEquals(mpc.getValues(), new Double[] {});
+
+    }
+
+}

--- a/implementation/src/test/java/io/smallrye/metrics/configuration/TimerConfigurationTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/configuration/TimerConfigurationTest.java
@@ -1,0 +1,137 @@
+package io.smallrye.metrics.configuration;
+
+import java.time.Duration;
+import java.util.Collection;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.metrics.setup.config.TimerBucketConfiguration;
+
+public class TimerConfigurationTest {
+
+    @Test
+    public void testGoodConfiguration() {
+        String input = "test.metric1=523ms,2s,1m,3h;test.metric2=600,345ms,45,1s";
+
+        Collection<TimerBucketConfiguration> collection = TimerBucketConfiguration.parse(input);
+
+        TimerBucketConfiguration tbc = TimerBucketConfiguration.matches(collection, "test.metric1");
+
+        Assertions.assertEquals(tbc.getMetricNameGrouping(), "test.metric1");
+        Assertions.assertArrayEquals(tbc.getValues(), new Duration[] { Duration.ofMillis(523), Duration.ofSeconds(2),
+                Duration.ofMinutes(1), Duration.ofHours(3) });
+
+        tbc = TimerBucketConfiguration.matches(collection, "test.metric2");
+
+        Assertions.assertEquals(tbc.getMetricNameGrouping(), "test.metric2");
+        Assertions.assertArrayEquals(tbc.getValues(), new Duration[] { Duration.ofMillis(45), Duration.ofMillis(345),
+                Duration.ofMillis(600), Duration.ofSeconds(1) });
+
+    }
+
+    @Test
+    public void testNonExistentvalue() {
+        String input = "test.metric1=523ms,2s,1m,3h;test.metric2=600,345ms,45,1s";
+
+        Collection<TimerBucketConfiguration> collection = TimerBucketConfiguration.parse(input);
+
+        TimerBucketConfiguration tbc = TimerBucketConfiguration.matches(collection, "test.metric3");
+
+        Assertions.assertNull(tbc);
+    }
+
+    @Test
+    public void testOverride1() {
+        String input = "test.metric1=523ms,2s,1m,3h;test.metric2=45;test.sub.metric1=78s,1s;test.*=99";
+
+        Collection<TimerBucketConfiguration> collection = TimerBucketConfiguration.parse(input);
+
+        TimerBucketConfiguration tbc = TimerBucketConfiguration.matches(collection, "test.metric1");
+        Assertions.assertEquals(tbc.getMetricNameGrouping(), "test.*");
+        Assertions.assertArrayEquals(tbc.getValues(), new Duration[] { Duration.ofMillis(99) });
+
+        tbc = TimerBucketConfiguration.matches(collection, "test.metric2");
+        Assertions.assertEquals(tbc.getMetricNameGrouping(), "test.*");
+        Assertions.assertArrayEquals(tbc.getValues(), new Duration[] { Duration.ofMillis(99) });
+
+        tbc = TimerBucketConfiguration.matches(collection, "test.sub.metric1");
+        Assertions.assertEquals(tbc.getMetricNameGrouping(), "test.*");
+        Assertions.assertArrayEquals(tbc.getValues(), new Duration[] { Duration.ofMillis(99) });
+    }
+
+    @Test
+    public void testOverride2() {
+        String input = "test.*=99;test.metric1=850ms,2s;test.metric2=45;test.sub.metric1=78s,1s";
+
+        Collection<TimerBucketConfiguration> collection = TimerBucketConfiguration.parse(input);
+
+        TimerBucketConfiguration tbc = TimerBucketConfiguration.matches(collection, "test.metric1");
+        Assertions.assertEquals(tbc.getMetricNameGrouping(), "test.metric1");
+        Assertions.assertArrayEquals(tbc.getValues(), new Duration[] { Duration.ofMillis(850), Duration.ofSeconds(2) });
+
+        tbc = TimerBucketConfiguration.matches(collection, "test.metric2");
+        Assertions.assertEquals(tbc.getMetricNameGrouping(), "test.metric2");
+        Assertions.assertArrayEquals(tbc.getValues(), new Duration[] { Duration.ofMillis(45) });
+
+        tbc = TimerBucketConfiguration.matches(collection, "test.sub.metric1");
+        Assertions.assertEquals(tbc.getMetricNameGrouping(), "test.sub.metric1");
+        Assertions.assertArrayEquals(tbc.getValues(), new Duration[] { Duration.ofSeconds(1), Duration.ofSeconds(78) });
+
+        tbc = TimerBucketConfiguration.matches(collection, "test.other.metric");
+        Assertions.assertEquals(tbc.getMetricNameGrouping(), "test.*");
+        Assertions.assertArrayEquals(tbc.getValues(), new Duration[] { Duration.ofMillis(99) });
+    }
+
+    @Test
+    public void testOverride3() {
+        String input = "*=123ms;test.*=45ms,1s";
+
+        Collection<TimerBucketConfiguration> collection = TimerBucketConfiguration.parse(input);
+
+        TimerBucketConfiguration tbc = TimerBucketConfiguration.matches(collection, "test.metric1");
+        Assertions.assertEquals(tbc.getMetricNameGrouping(), "test.*");
+        Assertions.assertArrayEquals(tbc.getValues(), new Duration[] { Duration.ofMillis(45), Duration.ofSeconds(1) });
+
+        tbc = TimerBucketConfiguration.matches(collection, "other.metric1");
+        Assertions.assertEquals(tbc.getMetricNameGrouping(), "*");
+        Assertions.assertArrayEquals(tbc.getValues(), new Duration[] { Duration.ofMillis(123) });
+
+    }
+
+    @Test
+    public void testBadValue1() {
+
+        /*
+         * test.metric1 has no valid values
+         * test.metric2 hs valid value for 34(ms)
+         */
+        String input = "test.metric1=12.0ms;test.metric2=34fj,78.0s,*(ms,fjm,34";
+
+        Collection<TimerBucketConfiguration> collection = TimerBucketConfiguration.parse(input);
+
+        TimerBucketConfiguration tbc = TimerBucketConfiguration.matches(collection, "test.metric1");
+        Assertions.assertEquals(tbc.getMetricNameGrouping(), "test.metric1");
+        Assertions.assertArrayEquals(tbc.getValues(), new Duration[] {});
+
+        tbc = TimerBucketConfiguration.matches(collection, "test.metric2");
+        Assertions.assertEquals(tbc.getMetricNameGrouping(), "test.metric2");
+        Assertions.assertArrayEquals(tbc.getValues(), new Duration[] { Duration.ofMillis(34) });
+
+    }
+
+    @Test
+    public void testBadValue2() {
+        String input = "test.metric1=test.metric2=12ms";
+
+        Collection<TimerBucketConfiguration> collection = TimerBucketConfiguration.parse(input);
+
+        TimerBucketConfiguration tbc = TimerBucketConfiguration.matches(collection, "test.metric1");
+        Assertions.assertEquals(tbc.getMetricNameGrouping(), "test.metric1");
+        Assertions.assertArrayEquals(tbc.getValues(), new Duration[] {});
+
+        tbc = TimerBucketConfiguration.matches(collection, "test.metric2");
+        Assertions.assertNull(tbc);
+
+    }
+}

--- a/implementation/src/test/java/io/smallrye/metrics/registration/MetadataMismatchTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/registration/MetadataMismatchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, 2022 Red Hat, Inc. and/or its affiliates
+ * Copyright 2019, 2023 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,23 +16,17 @@
  */
 package io.smallrye.metrics.registration;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.eclipse.microprofile.metrics.Histogram;
 import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.MetricFilter;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.Tag;
-import org.junit.After;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.metrics.SharedMetricRegistries;
 
@@ -40,26 +34,22 @@ public class MetadataMismatchTest {
 
     private MetricRegistry registry = SharedMetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
 
-    @After
+    @AfterEach
     public void cleanupApplicationMetrics() {
         registry.removeMatching(MetricFilter.ALL);
     }
 
-    @Ignore
-    // FIXME: this fails because the second registration goes through, I think that should be fixed
+    @Disabled
     @Test
     public void metricsWithDifferentMetadata() {
         Metadata metadata1 = Metadata.builder().withName("myhistogram").withDescription("description1").build();
         Metadata metadata2 = Metadata.builder().withName("myhistogram").withDescription("description2").build();
 
         registry.histogram(metadata1);
-        try {
-            registry.histogram(metadata2);
-            fail("Shouldn't be able to re-register a metric with different metadata");
-        } catch (Exception e) {
-            assertThat(e, instanceOf(IllegalStateException.class));
-            assertEquals(1, registry.getMetrics().size());
-        }
+
+        Assertions.assertThrows(IllegalStateException.class, () -> registry.histogram(metadata2));
+
+        Assertions.assertEquals(1, registry.getMetrics().size());
     }
 
     @Test
@@ -69,9 +59,11 @@ public class MetadataMismatchTest {
         Histogram histogram1 = registry.histogram(metadata, new Tag("color", "blue"));
         Histogram histogram2 = registry.histogram(metadata, new Tag("color", "red"));
 
-        assertNotEquals(histogram1, histogram2);
-        assertEquals(2, registry.getMetrics().size());
-        assertThat(registry.getMetadata().get("myhistogram").description().get(), equalTo("description1"));
+        Assertions.assertNotEquals(histogram1, histogram2);
+        Assertions.assertEquals(2, registry.getMetrics().size());
+
+        assertThat(registry.getMetadata().get("myhistogram").description().get()).isEqualTo("description1");
+
     }
 
     @Test
@@ -85,15 +77,12 @@ public class MetadataMismatchTest {
         // Mismatched metadata - expect IAE
         // Histogram histogram2 = registry.histogram(METRIC_NAME);
 
-        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+        Assertions.assertThrows(IllegalArgumentException.class,
                 () -> registry.histogram(METRIC_NAME));
 
-        assertNotNull(e);
-
-        e = assertThrows(IllegalArgumentException.class,
+        Assertions.assertThrows(IllegalArgumentException.class,
                 () -> registry.histogram("myhistogram", new Tag("color", "blue")));
 
-        assertNotNull(e);
     }
 
     @Test
@@ -104,8 +93,8 @@ public class MetadataMismatchTest {
         Histogram histogram1 = registry.histogram(metadata1);
         Histogram histogram2 = registry.histogram(metadata2);
 
-        assertEquals(histogram1, histogram2);
-        assertEquals(1, registry.getMetrics().size());
+        Assertions.assertEquals(histogram1, histogram2);
+        Assertions.assertEquals(1, registry.getMetrics().size());
     }
 
 }

--- a/implementation/src/test/java/io/smallrye/metrics/registration/MetricTypeMismatchTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/registration/MetricTypeMismatchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * Copyright 2019, 2023 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,14 +16,12 @@
  */
 package io.smallrye.metrics.registration;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.*;
-
 import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.MetricFilter;
 import org.eclipse.microprofile.metrics.MetricRegistry;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.metrics.SharedMetricRegistries;
 
@@ -31,7 +29,7 @@ public class MetricTypeMismatchTest {
 
     private MetricRegistry registry = SharedMetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
 
-    @After
+    @AfterEach
     public void cleanupApplicationMetrics() {
         registry.removeMatching(MetricFilter.ALL);
     }
@@ -44,12 +42,9 @@ public class MetricTypeMismatchTest {
                 .withDescription("description1").build();
 
         registry.histogram(metadata1);
-        try {
-            registry.timer(metadata2);
-            fail("Must not be able to register if a metric with different type is registered under the same name");
-        } catch (Exception e) {
-            assertThat(e, instanceOf(IllegalStateException.class));
-            assertEquals(1, registry.getMetrics().size());
-        }
+
+        Assertions.assertThrows(IllegalStateException.class, () -> registry.timer(metadata2));
+        Assertions.assertEquals(1, registry.getMetrics().size());
+
     }
 }

--- a/implementation/src/test/java/io/smallrye/metrics/registration/ReusabilityByDefaultTest.java
+++ b/implementation/src/test/java/io/smallrye/metrics/registration/ReusabilityByDefaultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * Copyright 2019, 2023 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,17 +17,16 @@
 
 package io.smallrye.metrics.registration;
 
-import static org.junit.Assert.assertEquals;
-
 import java.time.Duration;
 
 import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.MetricFilter;
 import org.eclipse.microprofile.metrics.MetricRegistry;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
@@ -41,20 +40,20 @@ public class ReusabilityByDefaultTest {
 
     private final MetricRegistry registry = SharedMetricRegistries.getOrCreate(MetricRegistry.APPLICATION_SCOPE);
 
-    @After
+    @AfterEach
     public void removeMetrics() {
         registry.removeMatching(MetricFilter.ALL);
     }
 
     static MeterRegistry rootRegistry;
 
-    @BeforeClass
+    @BeforeAll
     public static void addRegistries() {
         rootRegistry = new SimpleMeterRegistry();
         Metrics.addRegistry(rootRegistry);
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanup() {
         Metrics.removeRegistry(rootRegistry);
     }
@@ -63,14 +62,14 @@ public class ReusabilityByDefaultTest {
     public void testCounter() {
         registry.counter("mycounter").inc(1);
         registry.counter("mycounter").inc(1);
-        assertEquals(2, registry.counter("mycounter").getCount());
+        Assertions.assertEquals(2, registry.counter("mycounter").getCount());
     }
 
     @Test
     public void testHistogram() {
         registry.histogram("myhistogram").update(5);
         registry.histogram("myhistogram").update(3);
-        assertEquals(2, registry.histogram("myhistogram").getCount());
+        Assertions.assertEquals(2, registry.histogram("myhistogram").getCount());
     }
 
     @Test
@@ -78,7 +77,7 @@ public class ReusabilityByDefaultTest {
         Metadata metadata = Metadata.builder().withName("mytimer").build();
         registry.timer(metadata).update(Duration.ofNanos(5));
         registry.timer(metadata).update(Duration.ofNanos(7));
-        assertEquals(2, registry.timer("mytimer").getCount());
+        Assertions.assertEquals(2, registry.timer("mytimer").getCount());
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
 
   <parent>
     <groupId>io.smallrye</groupId>
-    <artifactId>smallrye-jakarta-parent</artifactId>
-    <version>34</version>
+    <artifactId>smallrye-parent</artifactId>
+    <version>40</version>
   </parent>
 
   <artifactId>smallrye-metrics-parent</artifactId>


### PR DESCRIPTION
- Update to Junit 5
- Write new junits for v51 metric config parsing Fixes:
- MetricPercentileConfiguration - no input
- Sort TimerBucketConfiguration values
- Default of millis instead of seconds for timer max/min config